### PR TITLE
refactor(memory): Accept storeId in MemoryClient constructor

### DIFF
--- a/packages/core/src/clients/memory.ts
+++ b/packages/core/src/clients/memory.ts
@@ -21,32 +21,40 @@ import { BaseClient } from './base';
  * Memory client for interacting with Twilio Memory Service
  */
 export class MemoryClient extends BaseClient {
-  constructor(config: TACConfig, logger?: Logger) {
+  private readonly storeId: string;
+
+  constructor(config: TACConfig, storeId: string, logger?: Logger) {
     const baseUrl = config.region
       ? `https://memory.${config.region}.twilio.com`
       : 'https://memory.twilio.com';
     super(baseUrl, config, logger);
+    this.storeId = storeId;
+  }
+
+  /**
+   * Get the store ID this client is configured for
+   */
+  public getStoreId(): string {
+    return this.storeId;
   }
 
   /**
    * Retrieve memories for a specific profile
    *
-   * @param serviceSid - The memory service SID
    * @param profileId - The profile ID to retrieve memories for
    * @param request - Optional request parameters for filtering results
    * @returns Promise containing memory retrieval response
    */
   public async retrieveMemories(
-    serviceSid: string,
     profileId: string,
     request: Partial<MemoryRetrievalRequest> = {}
   ): Promise<MemoryRetrievalResponse> {
     try {
-      const url = `/v1/Stores/${serviceSid}/Profiles/${profileId}/Recall`;
+      const url = `/v1/Stores/${this.storeId}/Profiles/${profileId}/Recall`;
 
       this.logger.debug(
         {
-          memory_store_id: serviceSid,
+          memory_store_id: this.storeId,
           profile_id: profileId,
           request,
         },
@@ -77,7 +85,7 @@ export class MemoryClient extends BaseClient {
 
       this.logger.debug(
         {
-          memory_store_id: serviceSid,
+          memory_store_id: this.storeId,
           profile_id: profileId,
         },
         'Raw memory response received'
@@ -90,7 +98,7 @@ export class MemoryClient extends BaseClient {
         this.logger.warn(
           {
             profile_id: profileId,
-            memory_store_id: serviceSid,
+            memory_store_id: this.storeId,
             validation_errors: validatedResponse.error.errors,
           },
           'Invalid memory response format'
@@ -100,7 +108,7 @@ export class MemoryClient extends BaseClient {
 
       this.logger.debug(
         {
-          memory_store_id: serviceSid,
+          memory_store_id: this.storeId,
           profile_id: profileId,
           observation_count: validatedResponse.data.observations.length,
           summary_count: validatedResponse.data.summaries.length,
@@ -114,7 +122,7 @@ export class MemoryClient extends BaseClient {
         {
           error: error instanceof Error ? error.message : String(error),
           profile_id: profileId,
-          memory_store_id: serviceSid,
+          memory_store_id: this.storeId,
         },
         'Memory retrieval error'
       );
@@ -125,17 +133,12 @@ export class MemoryClient extends BaseClient {
   /**
    * Find profiles that contain a specific identifier value
    *
-   * @param serviceSid - The memory service SID
    * @param idType - Identifier type (e.g., 'phone', 'email')
    * @param value - Raw value captured for the identifier
    * @returns Promise containing profile lookup response with normalized value and matching profile IDs
    */
-  public async lookupProfile(
-    serviceSid: string,
-    idType: string,
-    value: string
-  ): Promise<ProfileLookupResponse> {
-    const url = `/v1/Stores/${serviceSid}/Profiles/Lookup`;
+  public async lookupProfile(idType: string, value: string): Promise<ProfileLookupResponse> {
+    const url = `/v1/Stores/${this.storeId}/Profiles/Lookup`;
 
     const requestBody = {
       idType,
@@ -156,17 +159,12 @@ export class MemoryClient extends BaseClient {
   /**
    * Fetch profile information with traits
    *
-   * @param serviceSid - The memory service SID
    * @param profileId - The profile ID to fetch
    * @param traitGroups - Optional list of trait group names to include
    * @returns Promise containing profile response with ID, created timestamp, and traits
    */
-  public async getProfile(
-    serviceSid: string,
-    profileId: string,
-    traitGroups?: string[]
-  ): Promise<ProfileResponse> {
-    const url = `/v1/Stores/${serviceSid}/Profiles/${profileId}`;
+  public async getProfile(profileId: string, traitGroups?: string[]): Promise<ProfileResponse> {
+    const url = `/v1/Stores/${this.storeId}/Profiles/${profileId}`;
 
     const params: Record<string, string> = {};
     if (traitGroups && traitGroups.length > 0) {
@@ -192,7 +190,6 @@ export class MemoryClient extends BaseClient {
   /**
    * Create an observation for a profile
    *
-   * @param serviceSid - The memory service SID
    * @param profileId - The profile ID to create the observation for
    * @param content - The observation content
    * @param source - Source of the observation (default: 'conversation-intelligence')
@@ -201,14 +198,13 @@ export class MemoryClient extends BaseClient {
    * @returns Promise containing the created observation
    */
   public async createObservation(
-    serviceSid: string,
     profileId: string,
     content: string,
     source: string = 'conversation-intelligence',
     conversationIds?: string[],
     occurredAt?: string
   ): Promise<CreateObservationResponse> {
-    const url = `/v1/Stores/${serviceSid}/Profiles/${profileId}/Observations`;
+    const url = `/v1/Stores/${this.storeId}/Profiles/${profileId}/Observations`;
 
     const requestBody: Record<string, unknown> = {
       content,
@@ -237,13 +233,11 @@ export class MemoryClient extends BaseClient {
   /**
    * Create conversation summaries for a profile
    *
-   * @param serviceSid - The memory service SID
    * @param profileId - The profile ID to create summaries for
    * @param summaries - Array of summary items to create
    * @returns Promise containing a success message for the created conversation summaries
    */
   public async createConversationSummaries(
-    serviceSid: string,
     profileId: string,
     summaries: Array<{
       content: string;
@@ -252,7 +246,7 @@ export class MemoryClient extends BaseClient {
       source?: string;
     }>
   ): Promise<CreateConversationSummariesResponse> {
-    const url = `/v1/Stores/${serviceSid}/Profiles/${profileId}/ConversationSummaries`;
+    const url = `/v1/Stores/${this.storeId}/Profiles/${profileId}/ConversationSummaries`;
 
     const requestBody = {
       summaries: summaries.map(s => ({

--- a/packages/core/src/lib/operator-result-processor.ts
+++ b/packages/core/src/lib/operator-result-processor.ts
@@ -161,6 +161,35 @@ export class OperatorResultProcessor {
       };
     }
 
+    // Check for memory store ID and verify it matches the client's store ID
+    if (!event.memoryStoreId) {
+      this.logger.warn({ conversation_id: event.conversationId }, 'No memory store ID in event');
+      return {
+        success: false,
+        skipped: false,
+        error: 'No memory store ID provided in event',
+        createdCount: 0,
+      };
+    }
+
+    const clientStoreId = this.memoryClient.getStoreId();
+    if (event.memoryStoreId !== clientStoreId) {
+      this.logger.debug(
+        {
+          conversation_id: event.conversationId,
+          event_store_id: event.memoryStoreId,
+          client_store_id: clientStoreId,
+        },
+        'Skipping event from different memory store'
+      );
+      return {
+        success: true,
+        skipped: true,
+        skipReason: `Event from different memory store: ${event.memoryStoreId} (expected ${clientStoreId})`,
+        createdCount: 0,
+      };
+    }
+
     // Process each operator result
     const results: OperatorProcessingResult[] = [];
 
@@ -288,17 +317,6 @@ export class OperatorResultProcessor {
       };
     }
 
-    // Check for memory store ID
-    if (!event.memoryStoreId) {
-      this.logger.warn({ conversation_id: event.conversationId }, 'No memory store ID in event');
-      return {
-        success: false,
-        skipped: false,
-        error: 'No memory store ID provided in event',
-        createdCount: 0,
-      };
-    }
-
     // Process based on operator type
     if (isObservationOperator) {
       return this.processObservationEvent(event, operatorResult, content, profileIds);
@@ -340,7 +358,6 @@ export class OperatorResultProcessor {
       for (const observation of observations) {
         try {
           await this.memoryClient.createObservation(
-            event.memoryStoreId!,
             profileId,
             observation,
             'conversation-intelligence',
@@ -423,11 +440,7 @@ export class OperatorResultProcessor {
           source: 'conversation-intelligence',
         }));
 
-        await this.memoryClient.createConversationSummaries(
-          event.memoryStoreId!,
-          profileId,
-          summaryItems
-        );
+        await this.memoryClient.createConversationSummaries(profileId, summaryItems);
         createdCount += summaries.length;
 
         this.logger.debug(

--- a/packages/core/src/lib/tac.ts
+++ b/packages/core/src/lib/tac.ts
@@ -122,7 +122,11 @@ export class TAC {
       // server-side — see the conversationsV1ServiceSid field comment above.
       tac.conversationsV1ServiceSid =
         conversationConfig.conversationsV1Bridge?.serviceId ?? undefined;
-      tac.memoryClient = new MemoryClient(tac.config, tac.logger.child({ component: 'memory' }));
+      tac.memoryClient = new MemoryClient(
+        tac.config,
+        conversationConfig.memoryStoreId,
+        tac.logger.child({ component: 'memory' })
+      );
 
       tac.knowledgeClient = new KnowledgeClient(
         tac.config,
@@ -335,17 +339,13 @@ export class TAC {
           'Retrieving memory for profile'
         );
         try {
-          const memoryResponse = await this.memoryClient.retrieveMemories(
-            this.memoryStoreId,
-            data.profileId,
-            {
-              conversationId: data.conversationId,
-              observationsLimit: this.config.memoryConfig.observationsLimit,
-              summariesLimit: this.config.memoryConfig.summariesLimit,
-              communicationsLimit: this.config.memoryConfig.communicationsLimit,
-              relevanceThreshold: this.config.memoryConfig.relevanceThreshold,
-            }
-          );
+          const memoryResponse = await this.memoryClient.retrieveMemories(data.profileId, {
+            conversationId: data.conversationId,
+            observationsLimit: this.config.memoryConfig.observationsLimit,
+            summariesLimit: this.config.memoryConfig.summariesLimit,
+            communicationsLimit: this.config.memoryConfig.communicationsLimit,
+            relevanceThreshold: this.config.memoryConfig.relevanceThreshold,
+          });
           memory = new TACMemoryResponse(memoryResponse);
           this.logger.debug({ profile_id: data.profileId }, 'Memory retrieved');
         } catch (error) {
@@ -556,7 +556,6 @@ export class TAC {
 
         // Lookup profile using appropriate identity type
         const lookupResponse = await this.memoryClient.lookupProfile(
-          this.memoryStoreId,
           identityType,
           session.authorInfo.address
         );
@@ -574,19 +573,18 @@ export class TAC {
         session.profileId = lookupResponse.profiles[0];
       }
 
-      // At this point, profileId is guaranteed to be defined (either provided or looked up)
-      const memoryResponse = await this.memoryClient.retrieveMemories(
-        this.memoryStoreId,
-        session.profileId!,
-        {
-          conversationId: session.conversationId,
-          query,
-          observationsLimit: this.config.memoryConfig.observationsLimit,
-          summariesLimit: this.config.memoryConfig.summariesLimit,
-          communicationsLimit: this.config.memoryConfig.communicationsLimit,
-          relevanceThreshold: this.config.memoryConfig.relevanceThreshold,
-        }
-      );
+      if (!session.profileId) {
+        throw new Error('Profile ID is required but was not resolved');
+      }
+
+      const memoryResponse = await this.memoryClient.retrieveMemories(session.profileId, {
+        conversationId: session.conversationId,
+        query,
+        observationsLimit: this.config.memoryConfig.observationsLimit,
+        summariesLimit: this.config.memoryConfig.summariesLimit,
+        communicationsLimit: this.config.memoryConfig.communicationsLimit,
+        relevanceThreshold: this.config.memoryConfig.relevanceThreshold,
+      });
       return new TACMemoryResponse(memoryResponse);
     } catch (error) {
       this.logger.warn(
@@ -621,11 +619,7 @@ export class TAC {
 
     try {
       const traitGroups = this.config.memoryConfig.traitGroups;
-      const profileResponse = await this.memoryClient.getProfile(
-        this.memoryStoreId,
-        profileId,
-        traitGroups
-      );
+      const profileResponse = await this.memoryClient.getProfile(profileId, traitGroups);
       return profileResponse;
     } catch (error) {
       this.logger.error({ err: error }, `Failed to fetch profile for ${profileId}`);

--- a/packages/tools/src/built-in/memory.ts
+++ b/packages/tools/src/built-in/memory.ts
@@ -22,6 +22,9 @@ interface MemoryRetrievalParams {
 /**
  * Create memory retrieval tool.
  *
+ * @param memoryClient - Memory client instance (must be initialized with storeId)
+ * @param profileId - Optional profile ID for memory retrieval
+ * @param conversationId - Optional conversation ID for memory retrieval
  * @param options - Optional overrides for tool metadata.
  * @param options.name - Tool name exposed to the LLM. Defaults to `retrieve_profile_memory`.
  * @param options.description - Tool description exposed to the LLM. Defaults to a
@@ -29,7 +32,6 @@ interface MemoryRetrievalParams {
  */
 export function createMemoryRetrievalTool(
   memoryClient: MemoryClient,
-  serviceSid: string,
   profileId?: string,
   conversationId?: string,
   options: { name?: string; description?: string } = {}
@@ -104,18 +106,17 @@ export function createMemoryRetrievalTool(
         }).filter(([_, value]) => value !== undefined)
       ) as Partial<MemoryRetrievalRequest>;
 
-      return memoryClient.retrieveMemories(serviceSid, profileId, request);
+      return memoryClient.retrieveMemories(profileId, request);
     }
   );
 }
 
 /**
  * Create factory function for memory tools
+ *
+ * @param memoryClient - Memory client instance (must be initialized with storeId)
  */
-export function createMemoryTools(
-  memoryClient: MemoryClient,
-  serviceSid: string
-): {
+export function createMemoryTools(memoryClient: MemoryClient): {
   forProfile: (
     profileId: string,
     conversationId?: string
@@ -127,9 +128,9 @@ export function createMemoryTools(
 } {
   return {
     forProfile: (profileId: string, conversationId?: string) =>
-      createMemoryRetrievalTool(memoryClient, serviceSid, profileId, conversationId),
+      createMemoryRetrievalTool(memoryClient, profileId, conversationId),
 
     forSession: (profileId?: string, conversationId?: string) =>
-      createMemoryRetrievalTool(memoryClient, serviceSid, profileId, conversationId),
+      createMemoryRetrievalTool(memoryClient, profileId, conversationId),
   };
 }

--- a/tests/cintel.test.ts
+++ b/tests/cintel.test.ts
@@ -190,7 +190,7 @@ describe('OperatorResultProcessor', () => {
 
   beforeEach(() => {
     const config = new TACConfig(getTestConfig());
-    memoryClient = new MemoryClient(config);
+    memoryClient = new MemoryClient(config, 'mem_service_01kbjqhhdpft0tbp21jt4ktbxg');
     processor = new OperatorResultProcessor(memoryClient, cintelConfig);
     mockAdapter = new MockAdapter((memoryClient as any).axiosInstance);
   });
@@ -516,7 +516,7 @@ describe('Memory Client Write Methods', () => {
 
   beforeEach(() => {
     const config = new TACConfig(getTestConfig());
-    memoryClient = new MemoryClient(config);
+    memoryClient = new MemoryClient(config, 'mem_service_01kbjqhhdpft0tbp21jt4ktbxg');
     mockAdapter = new MockAdapter((memoryClient as any).axiosInstance);
   });
 
@@ -538,7 +538,6 @@ describe('Memory Client Write Methods', () => {
         .reply(200, mockResponse);
 
       const result = await memoryClient.createObservation(
-        'mem_service_01kbjqhhdpft0tbp21jt4ktbxg',
         'profile_123',
         'Test observation',
         'conversation-intelligence',
@@ -562,7 +561,6 @@ describe('Memory Client Write Methods', () => {
 
       await expect(
         memoryClient.createObservation(
-          'mem_service_01kbjqhhdpft0tbp21jt4ktbxg',
           'profile_123',
           'Test observation'
         )
@@ -580,7 +578,6 @@ describe('Memory Client Write Methods', () => {
         .reply(200, mockResponse);
 
       const result = await memoryClient.createConversationSummaries(
-        'mem_service_01kbjqhhdpft0tbp21jt4ktbxg',
         'profile_123',
         [
           {
@@ -608,7 +605,6 @@ describe('Memory Client Write Methods', () => {
 
       await expect(
         memoryClient.createConversationSummaries(
-          'mem_service_01kbjqhhdpft0tbp21jt4ktbxg',
           'profile_123',
           [
             {

--- a/tests/memory-client.test.ts
+++ b/tests/memory-client.test.ts
@@ -21,7 +21,7 @@ describe('MemoryClient', () => {
 
   beforeEach(() => {
     const config = new TACConfig(getTestConfig());
-    memoryClient = new MemoryClient(config);
+    memoryClient = new MemoryClient(config, 'mem_service_01kbjqhhdpft0tbp21jt4ktbxg');
     mockAdapter = new MockAdapter((memoryClient as any).axiosInstance);
   });
 
@@ -41,7 +41,6 @@ describe('MemoryClient', () => {
         .reply(200, mockResponse);
 
       const result = await memoryClient.lookupProfile(
-        'mem_service_01kbjqhhdpft0tbp21jt4ktbxg',
         'phone',
         '+1 (317) 555-6789'
       );
@@ -55,7 +54,7 @@ describe('MemoryClient', () => {
         .reply(500);
 
       await expect(
-        memoryClient.lookupProfile('mem_service_01kbjqhhdpft0tbp21jt4ktbxg', 'phone', '+1234567890')
+        memoryClient.lookupProfile('phone', '+1234567890')
       ).rejects.toThrow(/Failed to lookup profile/);
     });
   });
@@ -73,7 +72,6 @@ describe('MemoryClient', () => {
         .reply(200, mockResponse);
 
       const result = await memoryClient.getProfile(
-        'mem_service_01kbjqhhdpft0tbp21jt4ktbxg',
         'mem_profile_00000000000000000000000001'
       );
 
@@ -95,7 +93,6 @@ describe('MemoryClient', () => {
         .reply(200, mockResponse);
 
       const result = await memoryClient.getProfile(
-        'mem_service_01kbjqhhdpft0tbp21jt4ktbxg',
         'mem_profile_00000000000000000000000001',
         ['group1']
       );
@@ -109,7 +106,7 @@ describe('MemoryClient', () => {
         .reply(404);
 
       await expect(
-        memoryClient.getProfile('mem_service_01kbjqhhdpft0tbp21jt4ktbxg', 'mem_profile_00000000000000000000000001')
+        memoryClient.getProfile('mem_profile_00000000000000000000000001')
       ).rejects.toThrow(/Failed to get profile/);
     });
   });
@@ -117,7 +114,7 @@ describe('MemoryClient', () => {
   describe('region support', () => {
     it('should use region in base URL when configured', () => {
       const config = new TACConfig({ ...getTestConfig(), region: 'test-region' });
-      const regionClient = new MemoryClient(config);
+      const regionClient = new MemoryClient(config, 'mem_service_01kbjqhhdpft0tbp21jt4ktbxg');
 
       expect((regionClient as any).baseUrl).toBe('https://memory.test-region.twilio.com');
     });

--- a/tests/memory-tool.test.ts
+++ b/tests/memory-tool.test.ts
@@ -5,7 +5,6 @@ import type { MemoryRetrievalResponse } from '@twilio/tac-core';
 
 describe('Memory Retrieval Tool', () => {
   let mockMemoryClient: MemoryClient;
-  const serviceSid = 'mem_service_test123';
   const profileId = 'mem_profile_test456';
 
   beforeEach(() => {
@@ -17,7 +16,7 @@ describe('Memory Retrieval Tool', () => {
 
   describe('createMemoryRetrievalTool', () => {
     it('should create a tool with correct name and description', () => {
-      const tool = createMemoryRetrievalTool(mockMemoryClient, serviceSid, profileId);
+      const tool = createMemoryRetrievalTool(mockMemoryClient, profileId);
 
       expect(tool.name).toBe('retrieve_profile_memory');
       expect(tool.description).toBe(
@@ -26,7 +25,7 @@ describe('Memory Retrieval Tool', () => {
     });
 
     it('should have correct parameter schema with camelCase names', () => {
-      const tool = createMemoryRetrievalTool(mockMemoryClient, serviceSid, profileId);
+      const tool = createMemoryRetrievalTool(mockMemoryClient, profileId);
 
       expect(tool.parameters.properties).toHaveProperty('query');
       expect(tool.parameters.properties).toHaveProperty('beginDate');
@@ -46,10 +45,10 @@ describe('Memory Retrieval Tool', () => {
 
       vi.mocked(mockMemoryClient.retrieveMemories).mockResolvedValue(mockResponse);
 
-      const tool = createMemoryRetrievalTool(mockMemoryClient, serviceSid, profileId);
+      const tool = createMemoryRetrievalTool(mockMemoryClient, profileId);
       await tool.implementation({});
 
-      expect(mockMemoryClient.retrieveMemories).toHaveBeenCalledWith(serviceSid, profileId, {});
+      expect(mockMemoryClient.retrieveMemories).toHaveBeenCalledWith(profileId, {});
     });
 
     it('should call retrieveMemories with custom values when params provided', async () => {
@@ -61,7 +60,7 @@ describe('Memory Retrieval Tool', () => {
 
       vi.mocked(mockMemoryClient.retrieveMemories).mockResolvedValue(mockResponse);
 
-      const tool = createMemoryRetrievalTool(mockMemoryClient, serviceSid, profileId);
+      const tool = createMemoryRetrievalTool(mockMemoryClient, profileId);
       await tool.implementation({
         query: 'test query',
         observationsLimit: 10,
@@ -71,7 +70,6 @@ describe('Memory Retrieval Tool', () => {
       });
 
       expect(mockMemoryClient.retrieveMemories).toHaveBeenCalledWith(
-        serviceSid,
         profileId,
         expect.objectContaining({
           query: 'test query',
@@ -92,14 +90,13 @@ describe('Memory Retrieval Tool', () => {
 
       vi.mocked(mockMemoryClient.retrieveMemories).mockResolvedValue(mockResponse);
 
-      const tool = createMemoryRetrievalTool(mockMemoryClient, serviceSid, profileId);
+      const tool = createMemoryRetrievalTool(mockMemoryClient, profileId);
       await tool.implementation({
         beginDate: '2024-01-01T00:00:00Z',
         endDate: '2024-12-31T23:59:59Z',
       });
 
       expect(mockMemoryClient.retrieveMemories).toHaveBeenCalledWith(
-        serviceSid,
         profileId,
         expect.objectContaining({
           beginDate: '2024-01-01T00:00:00Z',
@@ -109,7 +106,7 @@ describe('Memory Retrieval Tool', () => {
     });
 
     it('should throw error when profileId is missing', async () => {
-      const tool = createMemoryRetrievalTool(mockMemoryClient, serviceSid);
+      const tool = createMemoryRetrievalTool(mockMemoryClient);
 
       await expect(tool.implementation({})).rejects.toThrow('No profile ID available for memory retrieval');
     });
@@ -135,7 +132,7 @@ describe('Memory Retrieval Tool', () => {
 
       vi.mocked(mockMemoryClient.retrieveMemories).mockResolvedValue(mockResponse);
 
-      const tool = createMemoryRetrievalTool(mockMemoryClient, serviceSid, profileId);
+      const tool = createMemoryRetrievalTool(mockMemoryClient, profileId);
       const result = await tool.implementation({});
 
       expect(result).toEqual(mockResponse);
@@ -152,13 +149,12 @@ describe('Memory Retrieval Tool', () => {
 
       vi.mocked(mockMemoryClient.retrieveMemories).mockResolvedValue(mockResponse);
 
-      const tool = createMemoryRetrievalTool(mockMemoryClient, serviceSid, profileId);
+      const tool = createMemoryRetrievalTool(mockMemoryClient, profileId);
       await tool.implementation({
         query: 'customer preferences',
       });
 
       expect(mockMemoryClient.retrieveMemories).toHaveBeenCalledWith(
-        serviceSid,
         profileId,
         expect.objectContaining({
           query: 'customer preferences',
@@ -175,7 +171,7 @@ describe('Memory Retrieval Tool', () => {
 
       vi.mocked(mockMemoryClient.retrieveMemories).mockResolvedValue(mockResponse);
 
-      const tool = createMemoryRetrievalTool(mockMemoryClient, serviceSid, profileId);
+      const tool = createMemoryRetrievalTool(mockMemoryClient, profileId);
       await tool.implementation({
         observationsLimit: 0,
         summariesLimit: 0,
@@ -183,7 +179,6 @@ describe('Memory Retrieval Tool', () => {
       });
 
       expect(mockMemoryClient.retrieveMemories).toHaveBeenCalledWith(
-        serviceSid,
         profileId,
         expect.objectContaining({
           observationsLimit: 0,
@@ -202,12 +197,11 @@ describe('Memory Retrieval Tool', () => {
 
       vi.mocked(mockMemoryClient.retrieveMemories).mockResolvedValue(mockResponse);
 
-      const tool = createMemoryRetrievalTool(mockMemoryClient, serviceSid, profileId);
+      const tool = createMemoryRetrievalTool(mockMemoryClient, profileId);
 
       // Test minimum boundary
       await tool.implementation({ relevanceThreshold: 0.0 });
       expect(mockMemoryClient.retrieveMemories).toHaveBeenCalledWith(
-        serviceSid,
         profileId,
         expect.objectContaining({
           relevanceThreshold: 0.0,
@@ -217,7 +211,6 @@ describe('Memory Retrieval Tool', () => {
       // Test maximum boundary
       await tool.implementation({ relevanceThreshold: 1.0 });
       expect(mockMemoryClient.retrieveMemories).toHaveBeenCalledWith(
-        serviceSid,
         profileId,
         expect.objectContaining({
           relevanceThreshold: 1.0,

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -57,7 +57,6 @@ describe('Memory Functionality', () => {
       expect(result.hasMemoryFeatures).toBe(true);
       expect(result.rawData).toEqual(mockMemoryResponse);
       expect(memoryClient!.retrieveMemories).toHaveBeenCalledWith(
-        'mem_service_01kbjqhhdpft0tbp21jt4ktbxg',
         'mem_profile_existing',
         {
           conversationId: 'conv_test_123',
@@ -105,7 +104,6 @@ describe('Memory Functionality', () => {
 
       // Verify profile was looked up
       expect(memoryClient!.lookupProfile).toHaveBeenCalledWith(
-        'mem_service_01kbjqhhdpft0tbp21jt4ktbxg',
         'phone',
         '+1 (317) 555-6789'
       );
@@ -115,7 +113,6 @@ describe('Memory Functionality', () => {
 
       // Verify memory was retrieved with the looked up profile_id
       expect(memoryClient!.retrieveMemories).toHaveBeenCalledWith(
-        'mem_service_01kbjqhhdpft0tbp21jt4ktbxg',
         'mem_profile_00000000000000000000000001',
         {
           conversationId: 'conv_test_123',
@@ -168,7 +165,6 @@ describe('Memory Functionality', () => {
       // Verify first profile was used
       expect(session.profileId).toBe('mem_profile_00000000000000000000000001');
       expect(memoryClient!.retrieveMemories).toHaveBeenCalledWith(
-        'mem_service_01kbjqhhdpft0tbp21jt4ktbxg',
         'mem_profile_00000000000000000000000001',
         {
           conversationId: 'conv_test_123',
@@ -356,7 +352,6 @@ describe('Memory Functionality', () => {
 
       expect(result).toEqual(mockProfileResponse);
       expect(memoryClient!.getProfile).toHaveBeenCalledWith(
-        'mem_service_01kbjqhhdpft0tbp21jt4ktbxg',
         'profile_123',
         undefined
       );

--- a/tests/user-agent.test.ts
+++ b/tests/user-agent.test.ts
@@ -60,7 +60,7 @@ describe('User-Agent Header', () => {
   });
 
   it('should include User-Agent header in MemoryClient requests', async () => {
-    const client = new MemoryClient(config);
+    const client = new MemoryClient(config, 'test_store_id');
     mockAdapter = new MockAdapter((client as any).axiosInstance);
 
     let capturedHeaders: any;


### PR DESCRIPTION
## Summary

Refactored `MemoryClient` to accept `storeId` during initialization rather than passing it to each method call. This change simplifies the API, improves type safety, and provides a cleaner developer experience.

### Key Changes

**MemoryClient Constructor:**
```typescript
// Before
const memoryClient = new MemoryClient(config);
await memoryClient.retrieveMemories(storeId, profileId, request);
await memoryClient.createObservation(storeId, profileId, content, ...);

// After
const memoryClient = new MemoryClient(config, storeId);
await memoryClient.retrieveMemories(profileId, request);
await memoryClient.createObservation(profileId, content, ...);
```

**API Updates:**
- `MemoryClient` now requires `storeId` as the second constructor parameter
- Removed `storeId`/`serviceSid` parameter from all methods:
  - `retrieveMemories()`
  - `lookupProfile()`
  - `getProfile()`
  - `createObservation()`
  - `createConversationSummaries()`
- Added `getStoreId()` method to expose the configured store ID
- Memory tool factories updated to remove `storeId` parameter

**OperatorResultProcessor Improvements:**
- Moved memory store ID validation from operator-level to event-level
- Now validates once per event (instead of N times per operator result)
- Returns specific skip reason when store IDs don't match, preserving actionable information
- Previously: when all operators skipped → generic "All operator results were skipped"
- Now: event-level mismatch → specific "Event from different memory store: X (expected Y)"
- Short-circuits immediately when store IDs don't match (no operator processing)

**Code Quality:**
- Replaced non-null assertion operators (`!`) with explicit type guards
- Fixed all test instantiations to use new constructor signature
- All tests updated and passing (394/394 ✅)

### Benefits

1. **Cleaner API** - No need to pass `storeId` to every method
2. **Type Safety** - Store ID is bound at construction time
3. **Consistency** - All methods now follow the same pattern
4. **Better Performance** - Store ID validation runs once per event, not per operator result
5. **Better Observability** - Specific skip reasons preserved instead of being lost in aggregation
6. **Better DX** - More intuitive: create client once with store, use it multiple times

### Testing

All existing tests have been updated and pass successfully:
```bash
npm run test      # All 394 tests passing
npm run typecheck # No type errors
npm run lint      # No lint errors
```

### Breaking Changes

⚠️ **This is a breaking change** for users directly instantiating `MemoryClient`:

**Migration Guide:**
```typescript
// Old API
const client = new MemoryClient(config);
await client.retrieveMemories(storeId, profileId, request);
await client.lookupProfile(storeId, idType, value);
await client.getProfile(storeId, profileId, traitGroups);
await client.createObservation(storeId, profileId, content, ...);
await client.createConversationSummaries(storeId, profileId, summaries);

// New API
const client = new MemoryClient(config, storeId);
await client.retrieveMemories(profileId, request);
await client.lookupProfile(idType, value);
await client.getProfile(profileId, traitGroups);
await client.createObservation(profileId, content, ...);
await client.createConversationSummaries(profileId, summaries);
```

**Note:** Users consuming the SDK through the `TAC` class (recommended approach) are not affected, as the `TAC` class handles `MemoryClient` instantiation internally.

### Return Value Semantics

The `OperatorResultProcessor.processEvent()` distinguishes between:
- **Skip** (`success: true, skipped: true, skipReason: "..."`) - Event is not applicable to this processor (e.g., different store ID or CI configuration)
- **Error** (`success: false, error: "..."`) - Event is malformed or processing failed (e.g., missing required fields)

Store ID mismatches return a skip result with a specific reason, allowing callers to distinguish "not for us" from "something went wrong."

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link to Linear ticket: https://linear.app/n8n/issue/[TICKET-ID] -->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues -->

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Docs updated or follow-up ticket created
- [x] Tests included and passing
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)