### PR TITLE
chore: replace twilio-innovation org references with twilio

### DIFF
--- a/.claude/skills/sync-to-python-sdk/SKILL.md
+++ b/.claude/skills/sync-to-python-sdk/SKILL.md
@@ -14,7 +14,7 @@ This skill analyzes changes from the TypeScript SDK (`twilio-agent-connect-types
 
 The skill accepts the following arguments (can be combined):
 
-1. **GitHub PR URL**: `https://github.com/twilio-innovation/twilio-agent-connect-typescript/pull/123`
+1. **GitHub PR URL**: `https://github.com/twilio/twilio-agent-connect-typescript/pull/123`
 2. **No commit flag**: `--no-commit` (makes and stages changes, but skips commit/push/PR)
 
 **Examples:**
@@ -30,7 +30,7 @@ The skill accepts the following arguments (can be combined):
 
 - TypeScript SDK (source): Current working directory (this repo)
 - Python SDK (target): Clone to `~/.claude/cache/sync-to-python-sdk/twilio-agent-connect-python` (user's home directory)
-- GitHub org: `twilio-innovation`
+- GitHub org: `twilio`
 
 ## Determine Input Mode
 
@@ -68,12 +68,12 @@ Arguments: $ARGUMENTS (the full argument string)
 Before doing anything else, verify that the `gh` CLI is installed and authenticated with access to the target repo:
 
 ```bash
-gh repo view twilio-innovation/twilio-agent-connect-python --json name --jq '.name'
+gh repo view twilio/twilio-agent-connect-python --json name --jq '.name'
 ```
 
 - If this command succeeds (prints `twilio-agent-connect-python`), proceed to Phase 1.
 - If it fails for **any reason** (gh not installed, not authenticated, no repo access, network error, etc.), **STOP the skill immediately** and tell the user:
-  > This skill requires the GitHub CLI (`gh`) to be installed and authenticated with access to `twilio-innovation/twilio-agent-connect-python`.
+  > This skill requires the GitHub CLI (`gh`) to be installed and authenticated with access to `twilio/twilio-agent-connect-python`.
   >
   > Run `gh auth status` to check your authentication, or `gh auth login` to authenticate.
 
@@ -100,7 +100,7 @@ CACHE_VALID=false
 if [ -d "$LOCAL_PY_SDK_DIR/.git" ]; then
   cd "$LOCAL_PY_SDK_DIR"
   REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
-  if echo "$REMOTE_URL" | grep -qE "(twilio-innovation|twilio)/twilio-agent-connect-python"; then
+  if echo "$REMOTE_URL" | grep -qE "twilio/twilio-agent-connect-python"; then
     echo "✓ Found valid local Python SDK at: $LOCAL_PY_SDK_DIR"
     LOCAL_VALID=true
   fi
@@ -110,7 +110,7 @@ fi
 if [ -d "$CACHE_PY_SDK_DIR/.git" ]; then
   cd "$CACHE_PY_SDK_DIR"
   REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
-  if echo "$REMOTE_URL" | grep -qE "(twilio-innovation|twilio)/twilio-agent-connect-python"; then
+  if echo "$REMOTE_URL" | grep -qE "twilio/twilio-agent-connect-python"; then
     echo "✓ Found valid cache Python SDK at: $CACHE_PY_SDK_DIR"
     CACHE_VALID=true
   fi
@@ -184,7 +184,7 @@ Only proceed with this step if either:
 
 ```bash
 mkdir -p "$(dirname "$PY_SDK_DIR")"
-gh repo clone twilio-innovation/twilio-agent-connect-python "$PY_SDK_DIR"
+gh repo clone twilio/twilio-agent-connect-python "$PY_SDK_DIR"
 ```
 
 **Else (update and reset existing repo):**
@@ -205,13 +205,13 @@ Fetch PR details and diff using GitHub CLI:
 
 ```bash
 # Get PR metadata
-gh pr view <PR_NUMBER> --repo twilio-innovation/twilio-agent-connect-typescript --json title,body,headRefName,baseRefName,files,url
+gh pr view <PR_NUMBER> --repo twilio/twilio-agent-connect-typescript --json title,body,headRefName,baseRefName,files,url
 
 # Get the diff
-gh pr diff <PR_NUMBER> --repo twilio-innovation/twilio-agent-connect-typescript
+gh pr diff <PR_NUMBER> --repo twilio/twilio-agent-connect-typescript
 
 # Get list of changed files
-gh pr view <PR_NUMBER> --repo twilio-innovation/twilio-agent-connect-typescript --json files --jq '.files[].path'
+gh pr view <PR_NUMBER> --repo twilio/twilio-agent-connect-typescript --json files --jq '.files[].path'
 ```
 
 Store:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@
 
 ## SDK Parity
 
-This is the **TypeScript SDK**. If this change affects shared functionality, ensure the [Python SDK](https://github.com/twilio-innovation/twilio-agent-connect-python) is updated as well.
+This is the **TypeScript SDK**. If this change affects shared functionality, ensure the [Python SDK](https://github.com/twilio/twilio-agent-connect-python) is updated as well.
 
 > **Tip:** Use the `/sync-to-python-sdk` skill in Claude Code to automatically generate and create a Python SDK PR from your changes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Twilio Agent Connect - TypeScript SDK
 
-A TypeScript framework for building AI-powered conversational agents on Twilio infrastructure. Provides channel abstractions (SMS, Voice), tool integration, memory/knowledge APIs, and a production-ready Fastify server — designed for 1:1 parity with the [Python SDK](https://github.com/twilio-innovation/twilio-agent-connect-python).
+A TypeScript framework for building AI-powered conversational agents on Twilio infrastructure. Provides channel abstractions (SMS, Voice), tool integration, memory/knowledge APIs, and a production-ready Fastify server — designed for 1:1 parity with the [Python SDK](https://github.com/twilio/twilio-agent-connect-python).
 
 ## Development Commands
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,7 +23,7 @@ twilio-agent-connect-typescript/
 
 ```bash
 # Clone and install
-git clone https://github.com/twilio-innovation/twilio-agent-connect-typescript.git
+git clone https://github.com/twilio/twilio-agent-connect-typescript.git
 cd twilio-agent-connect-typescript
 npm install
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ context-aware applications using Twilio's communication technologies. TAC provid
 Memory and Conversation services, enabling you to build LLM-powered agents with persistent memory and conversation context.
 
 > [!NOTE]
-> Looking for the Python version? Check out [TAC SDK Python](https://github.com/twilio-innovation/twilio-agent-connect-python).
+> Looking for the Python version? Check out [TAC SDK Python](https://github.com/twilio/twilio-agent-connect-python).
 
 Explore the [getting_started](getting_started) directory to see the SDK in action.
 
@@ -32,7 +32,7 @@ To get started, set up your Node.js environment (Node.js 22.13.0 or newer requir
 Clone this repository and work within it:
 
 ```bash
-git clone https://github.com/twilio-innovation/twilio-agent-connect-typescript.git
+git clone https://github.com/twilio/twilio-agent-connect-typescript.git
 cd twilio-agent-connect-typescript
 
 # Install dependencies
@@ -47,7 +47,7 @@ npm run build
 If you have an existing project, you can install directly from GitHub:
 
 ```bash
-npm install git@github.com:twilio-innovation/twilio-agent-connect-typescript.git
+npm install git@github.com:twilio/twilio-agent-connect-typescript.git
 ```
 
 ## Quick Examples
@@ -200,7 +200,7 @@ npm --version   # Should be 9 or newer
 
 ```bash
 # Clone repository
-git clone https://github.com/twilio-innovation/twilio-agent-connect-typescript.git
+git clone https://github.com/twilio/twilio-agent-connect-typescript.git
 cd twilio-agent-connect-typescript
 
 # Install all dependencies

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/twilio-innovation/twilio-agent-connect-typescript.git"
+    "url": "https://github.com/twilio/twilio-agent-connect-typescript.git"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",


### PR DESCRIPTION
## Summary

Replace all references to the old `twilio-innovation` GitHub org with `twilio` across documentation, config, and tooling files.

- README.md (4 occurrences)
- package.json repository URL
- DEVELOPMENT.md clone URL
- CLAUDE.md Python SDK link
- .github/PULL_REQUEST_TEMPLATE.md Python SDK link
- .claude/skills/sync-to-python-sdk/SKILL.md (11 occurrences, including simplifying regex patterns)

## Type of Change

- [x] Documentation update

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated
- [ ] Tested E2E

## SDK Parity

- [x] Change is TypeScript-specific (no Python update needed)