### PR TITLE
fix(core): Remove PII from log output

### DIFF
--- a/packages/core/src/channels/base.ts
+++ b/packages/core/src/channels/base.ts
@@ -179,7 +179,7 @@ export abstract class BaseChannel {
    * Handle errors with proper context
    */
   protected handleError(error: Error, context?: Record<string, unknown>): void {
-    this.logger.error({ err: error, ...context }, 'Channel error');
+    this.logger.error({ err: error }, 'Channel error');
 
     if (this.callbacks.onError) {
       if (context) {

--- a/packages/core/src/channels/chat.ts
+++ b/packages/core/src/channels/chat.ts
@@ -65,7 +65,7 @@ export class ChatChannel extends MessagingChannel {
   public async sendResponse(
     conversationId: ConversationId,
     message: string,
-    _metadata?: Record<string, unknown>
+    metadata?: Record<string, unknown>
   ): Promise<void> {
     this.logger.debug(
       {
@@ -179,6 +179,8 @@ export class ChatChannel extends MessagingChannel {
       this.logger.error({ err: error, conversation_id: conversationId }, 'Send response error');
       this.handleError(error instanceof Error ? error : new Error(String(error)), {
         conversationId,
+        message,
+        metadata,
       });
       throw error;
     }

--- a/packages/core/src/channels/chat.ts
+++ b/packages/core/src/channels/chat.ts
@@ -8,6 +8,7 @@ import {
 import { z } from 'zod';
 import { MessagingChannel, MessagingChannelConfig } from './messaging';
 import type { TAC } from '../lib/tac';
+import { maskAddress } from '../util/log-redaction';
 
 /**
  * Options for initiating an outbound chat conversation
@@ -64,7 +65,7 @@ export class ChatChannel extends MessagingChannel {
   public async sendResponse(
     conversationId: ConversationId,
     message: string,
-    metadata?: Record<string, unknown>
+    _metadata?: Record<string, unknown>
   ): Promise<void> {
     this.logger.debug(
       {
@@ -178,8 +179,6 @@ export class ChatChannel extends MessagingChannel {
       this.logger.error({ err: error, conversation_id: conversationId }, 'Send response error');
       this.handleError(error instanceof Error ? error : new Error(String(error)), {
         conversationId,
-        message,
-        metadata,
       });
       throw error;
     }
@@ -197,7 +196,7 @@ export class ChatChannel extends MessagingChannel {
     const validated = InitiateChatConversationOptionsSchema.parse(options);
 
     this.logger.info(
-      { to: validated.to, channel_id: validated.channelId },
+      { to: maskAddress(validated.to), channel_id: validated.channelId },
       'Initiating outbound chat conversation'
     );
 

--- a/packages/core/src/channels/messaging.ts
+++ b/packages/core/src/channels/messaging.ts
@@ -11,6 +11,7 @@ import {
 } from '../types/index';
 import { BaseChannel, BaseChannelEvents } from './base';
 import type { TAC } from '../lib/tac';
+import { maskAddress } from '../util/log-redaction';
 
 /**
  * Messaging webhook event types from Twilio Conversations Service
@@ -223,7 +224,7 @@ export abstract class MessagingChannel extends BaseChannel {
    * Process messaging channel webhook from Twilio Conversations Service
    */
   public async processWebhook(payload: unknown, idempotencyToken?: string): Promise<void> {
-    this.logger.debug({ operation: 'webhook_processing', payload }, 'Processing webhook');
+    this.logger.debug({ operation: 'webhook_processing' }, 'Processing webhook');
 
     try {
       if (idempotencyToken && this.isDuplicateWebhook(idempotencyToken)) {
@@ -293,7 +294,6 @@ export abstract class MessagingChannel extends BaseChannel {
               event_type: eventType,
               raw_event_type: webhookData.eventType,
               conversation_id: conversationId,
-              payload,
             },
             'Unhandled event type - this event will be ignored'
           );
@@ -309,7 +309,7 @@ export abstract class MessagingChannel extends BaseChannel {
         { err: error, operation: 'webhook_processing' },
         'Webhook processing error'
       );
-      this.handleError(error instanceof Error ? error : new Error(String(error)), { payload });
+      this.handleError(error instanceof Error ? error : new Error(String(error)));
     }
   }
 
@@ -322,7 +322,7 @@ export abstract class MessagingChannel extends BaseChannel {
 
     if (!conversationId) {
       this.logger.warn(
-        { payload, operation: 'handle_conversation_created' },
+        { operation: 'handle_conversation_created' },
         'Missing conversation ID in conversation.created event'
       );
       throw new Error('Missing conversation ID in conversation.created event');
@@ -340,7 +340,7 @@ export abstract class MessagingChannel extends BaseChannel {
 
     if (!conversationId) {
       this.logger.warn(
-        { payload, operation: 'handle_participant_added' },
+        { operation: 'handle_participant_added' },
         'Missing conversation ID in participant.added event'
       );
       throw new Error('Missing conversation ID in participant.added event');
@@ -399,8 +399,7 @@ export abstract class MessagingChannel extends BaseChannel {
       {
         conversation_id: conversationId,
         profile_id: profileId,
-        author,
-        message,
+        author: maskAddress(author),
         message_length: message?.length,
         operation: 'handle_communication_created',
       },
@@ -409,7 +408,7 @@ export abstract class MessagingChannel extends BaseChannel {
 
     if (!conversationId) {
       this.logger.warn(
-        { payload, operation: 'handle_communication_created' },
+        { operation: 'handle_communication_created' },
         'Missing conversation ID in communication.created event'
       );
       throw new Error('Missing conversation ID in communication.created event');
@@ -441,7 +440,7 @@ export abstract class MessagingChannel extends BaseChannel {
       this.logger.info(
         {
           conversation_id: conversationId,
-          author_address: author,
+          author_address: maskAddress(author),
         },
         'Ignoring message from AI agent'
       );
@@ -499,7 +498,10 @@ export abstract class MessagingChannel extends BaseChannel {
     // Retrieve user memory using tac.retrieveMemory, which handles profile lookup by address (e.g., phone number or email)
     let userMemory;
     if (session) {
-      this.logger.debug({ conversation_id: conversationId, author }, 'Retrieving user memory');
+      this.logger.debug(
+        { conversation_id: conversationId, author: maskAddress(author) },
+        'Retrieving user memory'
+      );
       try {
         userMemory = await this.tac.retrieveMemory(session, message);
         this.logger.debug(
@@ -631,7 +633,7 @@ export abstract class MessagingChannel extends BaseChannel {
       {
         conversation_id: conversationId,
         channel: agentAddress.channel,
-        address: agentAddress.address,
+        address: maskAddress(agentAddress.address),
       },
       'No agent participant found, creating AI_AGENT'
     );
@@ -794,7 +796,7 @@ export abstract class MessagingChannel extends BaseChannel {
       await this.conversationClient.createAction(conversationId, actionRequest);
 
       this.logger.info(
-        { conversation_id: conversationId, to },
+        { conversation_id: conversationId, to: maskAddress(to) },
         `Outbound ${channel} conversation initiated`
       );
 
@@ -813,8 +815,13 @@ export abstract class MessagingChannel extends BaseChannel {
             );
           });
       }
-      this.logger.error({ err: error, to }, `Failed to initiate outbound ${channel}`);
-      this.handleError(error instanceof Error ? error : new Error(String(error)), { to });
+      this.logger.error(
+        { err: error, to: maskAddress(to) },
+        `Failed to initiate outbound ${channel}`
+      );
+      this.handleError(error instanceof Error ? error : new Error(String(error)), {
+        to: maskAddress(to),
+      });
       throw error;
     }
   }

--- a/packages/core/src/channels/messaging.ts
+++ b/packages/core/src/channels/messaging.ts
@@ -309,7 +309,7 @@ export abstract class MessagingChannel extends BaseChannel {
         { err: error, operation: 'webhook_processing' },
         'Webhook processing error'
       );
-      this.handleError(error instanceof Error ? error : new Error(String(error)));
+      this.handleError(error instanceof Error ? error : new Error(String(error)), { payload });
     }
   }
 
@@ -819,9 +819,7 @@ export abstract class MessagingChannel extends BaseChannel {
         { err: error, to: maskAddress(to) },
         `Failed to initiate outbound ${channel}`
       );
-      this.handleError(error instanceof Error ? error : new Error(String(error)), {
-        to: maskAddress(to),
-      });
+      this.handleError(error instanceof Error ? error : new Error(String(error)), { to });
       throw error;
     }
   }

--- a/packages/core/src/channels/sms.ts
+++ b/packages/core/src/channels/sms.ts
@@ -30,7 +30,7 @@ export class SMSChannel extends MessagingChannel {
   public async sendResponse(
     conversationId: ConversationId,
     message: string,
-    _metadata?: Record<string, unknown>
+    metadata?: Record<string, unknown>
   ): Promise<void> {
     this.logger.debug(
       {
@@ -137,6 +137,8 @@ export class SMSChannel extends MessagingChannel {
       this.logger.error({ err: error, conversation_id: conversationId }, 'Send response error');
       this.handleError(error instanceof Error ? error : new Error(String(error)), {
         conversationId,
+        message,
+        metadata,
       });
       throw error;
     }

--- a/packages/core/src/channels/sms.ts
+++ b/packages/core/src/channels/sms.ts
@@ -7,6 +7,7 @@ import {
   InitiateConversationResult,
 } from '../types/index';
 import { MessagingChannel } from './messaging';
+import { maskAddress, maskPhone } from '../util/log-redaction';
 
 /**
  * SMS Channel implementation for Twilio Conversations Service
@@ -29,7 +30,7 @@ export class SMSChannel extends MessagingChannel {
   public async sendResponse(
     conversationId: ConversationId,
     message: string,
-    metadata?: Record<string, unknown>
+    _metadata?: Record<string, unknown>
   ): Promise<void> {
     this.logger.debug(
       {
@@ -100,10 +101,10 @@ export class SMSChannel extends MessagingChannel {
       this.logger.debug(
         {
           conversation_id: conversationId,
-          recipient_address: recipientAddress,
+          recipient_address: maskAddress(recipientAddress),
           recipient_participant_id: customerParticipantId,
           agent_participant_id: agentParticipant.id,
-          from_number: agentAddress,
+          from_number: maskPhone(agentAddress),
         },
         'Sending SMS via Actions API'
       );
@@ -129,15 +130,13 @@ export class SMSChannel extends MessagingChannel {
       await this.conversationClient.createAction(conversationId, actionRequest);
 
       this.logger.info(
-        { conversation_id: conversationId, recipient_address: recipientAddress },
+        { conversation_id: conversationId, recipient_address: maskAddress(recipientAddress) },
         'SMS sent successfully via Actions API'
       );
     } catch (error) {
       this.logger.error({ err: error, conversation_id: conversationId }, 'Send response error');
       this.handleError(error instanceof Error ? error : new Error(String(error)), {
         conversationId,
-        message,
-        metadata,
       });
       throw error;
     }
@@ -155,7 +154,7 @@ export class SMSChannel extends MessagingChannel {
     const validated = InitiateMessagingConversationOptionsSchema.parse(options);
 
     this.logger.info(
-      { to: validated.to, message_length: validated.message.length },
+      { to: maskAddress(validated.to), message_length: validated.message.length },
       'Initiating outbound SMS conversation'
     );
 

--- a/packages/core/src/channels/voice.ts
+++ b/packages/core/src/channels/voice.ts
@@ -21,6 +21,7 @@ import type { InitiateVoiceConversationResult } from '../types/conversation';
 import { BaseChannel, BaseChannelEvents } from './base';
 import type { TAC } from '../lib/tac';
 import { TACMemoryResponse } from '../lib/tac-memory-response';
+import { maskAddress } from '../util/log-redaction';
 
 /**
  * Voice channel event callbacks extending base callbacks
@@ -152,7 +153,6 @@ export class VoiceChannel extends BaseChannel {
           if (!result.success) {
             this.logger.debug(
               {
-                raw_message: messageData,
                 validation_errors: result.error.errors.map(error => ({
                   path: error.path.join('.'),
                   message: error.message,
@@ -278,7 +278,6 @@ export class VoiceChannel extends BaseChannel {
                   .catch((err: unknown) => {
                     this.handleError(err instanceof Error ? err : new Error(String(err)), {
                       conversationId,
-                      message: data.toString(),
                     });
                   });
                 this.promptQueues.set(conversationId, currentPrompt);
@@ -295,7 +294,10 @@ export class VoiceChannel extends BaseChannel {
 
             default:
               this.logger.debug(
-                { conversation_id: conversationId, message: messageData },
+                {
+                  conversation_id: conversationId,
+                  message_type: (messageData as Record<string, unknown>)?.type,
+                },
                 'Unhandled WebSocket event type'
               );
               break;
@@ -304,7 +306,6 @@ export class VoiceChannel extends BaseChannel {
           this.handleError(error instanceof Error ? error : new Error(String(error)), {
             conversationId,
             callSid,
-            message: data.toString(),
           });
         }
       })().catch((err: unknown) => {
@@ -439,7 +440,7 @@ export class VoiceChannel extends BaseChannel {
   public sendResponse(
     conversationId: ConversationId,
     message: string,
-    metadata?: Record<string, unknown>
+    _metadata?: Record<string, unknown>
   ): Promise<void> {
     try {
       const ws = this.webSocketConnections.get(conversationId);
@@ -475,8 +476,6 @@ export class VoiceChannel extends BaseChannel {
     } catch (error) {
       this.handleError(error instanceof Error ? error : new Error(String(error)), {
         conversationId,
-        message,
-        metadata,
       });
       throw error;
     }
@@ -638,13 +637,19 @@ export class VoiceChannel extends BaseChannel {
         twiml,
       });
 
-      this.logger.info({ call_sid: call.sid, to: validated.to }, 'Outbound voice call placed');
+      this.logger.info(
+        { call_sid: call.sid, to: maskAddress(validated.to) },
+        'Outbound voice call placed'
+      );
 
       return { callSid: call.sid };
     } catch (error) {
-      this.logger.error({ err: error, to: validated.to }, 'Failed to initiate outbound call');
+      this.logger.error(
+        { err: error, to: maskAddress(validated.to) },
+        'Failed to initiate outbound call'
+      );
       this.handleError(error instanceof Error ? error : new Error(String(error)), {
-        to: validated.to,
+        to: maskAddress(validated.to),
       });
       throw error;
     }

--- a/packages/core/src/channels/voice.ts
+++ b/packages/core/src/channels/voice.ts
@@ -278,6 +278,7 @@ export class VoiceChannel extends BaseChannel {
                   .catch((err: unknown) => {
                     this.handleError(err instanceof Error ? err : new Error(String(err)), {
                       conversationId,
+                      message: data.toString(),
                     });
                   });
                 this.promptQueues.set(conversationId, currentPrompt);
@@ -306,6 +307,7 @@ export class VoiceChannel extends BaseChannel {
           this.handleError(error instanceof Error ? error : new Error(String(error)), {
             conversationId,
             callSid,
+            message: data.toString(),
           });
         }
       })().catch((err: unknown) => {
@@ -440,7 +442,7 @@ export class VoiceChannel extends BaseChannel {
   public sendResponse(
     conversationId: ConversationId,
     message: string,
-    _metadata?: Record<string, unknown>
+    metadata?: Record<string, unknown>
   ): Promise<void> {
     try {
       const ws = this.webSocketConnections.get(conversationId);
@@ -476,6 +478,8 @@ export class VoiceChannel extends BaseChannel {
     } catch (error) {
       this.handleError(error instanceof Error ? error : new Error(String(error)), {
         conversationId,
+        message,
+        metadata,
       });
       throw error;
     }
@@ -649,7 +653,7 @@ export class VoiceChannel extends BaseChannel {
         'Failed to initiate outbound call'
       );
       this.handleError(error instanceof Error ? error : new Error(String(error)), {
-        to: maskAddress(validated.to),
+        to: validated.to,
       });
       throw error;
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,7 +51,7 @@ export { VoiceChannel } from './channels/voice';
 export type { VoiceChannelEvents, StreamTask } from './channels/voice';
 
 // Log redaction utilities
-export { maskPhone, maskEmail, maskAddress } from './util/log-redaction';
+export { maskPhone, maskEmail, maskAddress, scrubPii, scrubObject } from './util/log-redaction';
 
 // Studio handoff URL helpers
 export { studioExecutionsUrl, studioVoiceHandoffUrl } from './util/handoff-urls';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,6 +50,9 @@ export type {
 export { VoiceChannel } from './channels/voice';
 export type { VoiceChannelEvents, StreamTask } from './channels/voice';
 
+// Log redaction utilities
+export { maskPhone, maskEmail, maskAddress } from './util/log-redaction';
+
 // Studio handoff URL helpers
 export { studioExecutionsUrl, studioVoiceHandoffUrl } from './util/handoff-urls';
 

--- a/packages/core/src/lib/logger.ts
+++ b/packages/core/src/lib/logger.ts
@@ -8,9 +8,15 @@ export type Logger = pino.Logger;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function piiLogMethod(this: any, args: any[], method: pino.LogFn) {
+  /* eslint-disable @typescript-eslint/no-unsafe-return */
   const scrubbed = args.map(arg =>
-    typeof arg === 'string' ? scrubObject(arg) : typeof arg === 'object' && arg !== null ? scrubObject(arg) : arg
+    typeof arg === 'string'
+      ? scrubObject(arg)
+      : typeof arg === 'object' && arg !== null
+        ? scrubObject(arg)
+        : arg
   );
+  /* eslint-enable @typescript-eslint/no-unsafe-return */
   return method.apply(this, scrubbed as Parameters<pino.LogFn>);
 }
 

--- a/packages/core/src/lib/logger.ts
+++ b/packages/core/src/lib/logger.ts
@@ -7,8 +7,7 @@ import { scrubObject } from '../util/log-redaction';
 export type Logger = pino.Logger;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function piiLogMethod(this: any, args: any[], method: pino.LogFn) {
-  /* eslint-disable @typescript-eslint/no-unsafe-return */
+function piiLogMethod(this: any, args: unknown[], method: pino.LogFn) {
   const scrubbed = args.map(arg =>
     typeof arg === 'string'
       ? scrubObject(arg)
@@ -16,7 +15,6 @@ function piiLogMethod(this: any, args: any[], method: pino.LogFn) {
         ? scrubObject(arg)
         : arg
   );
-  /* eslint-enable @typescript-eslint/no-unsafe-return */
   return method.apply(this, scrubbed as Parameters<pino.LogFn>);
 }
 

--- a/packages/core/src/lib/logger.ts
+++ b/packages/core/src/lib/logger.ts
@@ -1,9 +1,18 @@
 import pino from 'pino';
+import { scrubObject } from '../util/log-redaction';
 
 /**
  * Logger type that can be either Pino logger or Fastify's logger
  */
 export type Logger = pino.Logger;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function piiLogMethod(this: any, args: any[], method: pino.LogFn) {
+  const scrubbed = args.map(arg =>
+    typeof arg === 'string' ? scrubObject(arg) : typeof arg === 'object' && arg !== null ? scrubObject(arg) : arg
+  );
+  return method.apply(this, scrubbed as Parameters<pino.LogFn>);
+}
 
 /**
  * Create a Pino logger with configured settings
@@ -23,6 +32,7 @@ export function createLogger(options?: {
   const pinoOptions: pino.LoggerOptions = {
     level,
     ...(options?.name && { name: options.name }),
+    hooks: { logMethod: piiLogMethod },
   };
 
   // Use pretty printing in development for better readability

--- a/packages/core/src/lib/tac.ts
+++ b/packages/core/src/lib/tac.ts
@@ -14,6 +14,7 @@ import { ConversationClient } from '../clients/conversation';
 import { KnowledgeClient } from '../clients/knowledge';
 import { BaseChannel } from '../channels/base';
 import { Logger, createLogger } from './logger';
+import { maskAddress } from '../util/log-redaction';
 import { OperatorResultProcessor } from './operator-result-processor';
 
 export interface TACOptions {
@@ -300,7 +301,7 @@ export class TAC {
       {
         conversation_id: data.conversationId,
         profile_id: data.profileId,
-        author: data.author,
+        author: maskAddress(data.author),
         message_length: data.message.length,
         channel: data.channelType,
         operation: 'handle_message_ready',
@@ -545,12 +546,12 @@ export class TAC {
           identityType = 'phone';
         } else {
           throw new Error(
-            `Unsupported authorInfo.address format '${address}'. ` +
+            `Unsupported authorInfo.address format '${maskAddress(address)}'. ` +
               "Expected an email address containing '@' or a phone number starting with '+'."
           );
         }
         this.logger.debug(
-          { identityType, address, channel: session.channel },
+          { identityType, address: maskAddress(address), channel: session.channel },
           'profileId not found, attempting to lookup profile'
         );
 
@@ -563,7 +564,7 @@ export class TAC {
         // Check if any profiles were found
         if (!lookupResponse.profiles || lookupResponse.profiles.length === 0) {
           throw new Error(
-            `No profile found for ${identityType} ${session.authorInfo.address}. ` +
+            `No profile found for ${identityType} ${maskAddress(session.authorInfo.address)}. ` +
               'Profile lookup returned no results. Ensure the identity ' +
               'is registered in the identity resolution system.'
           );

--- a/packages/core/src/util/log-redaction.ts
+++ b/packages/core/src/util/log-redaction.ts
@@ -29,14 +29,29 @@ export function scrubObject(obj: any, seen?: WeakSet<object>): any {
   visited.add(obj);
 
   if (obj instanceof Error) {
-    const scrubbed = new Error(scrubPii(obj.message));
-    scrubbed.name = obj.name;
-    if (obj.stack) scrubbed.stack = scrubPii(obj.stack);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const scrubbed = Object.create(Object.getPrototypeOf(obj)) as Error;
+    for (const key of Object.keys(obj)) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      (scrubbed as Record<string, unknown>)[key] = scrubObject(obj[key], visited);
+    }
+    if (!Object.prototype.hasOwnProperty.call(scrubbed, 'message')) {
+      scrubbed.message = scrubPii(obj.message);
+    }
+    if (!Object.prototype.hasOwnProperty.call(scrubbed, 'name')) {
+      scrubbed.name = obj.name;
+    }
+    if (obj.stack && !Object.prototype.hasOwnProperty.call(scrubbed, 'stack')) {
+      scrubbed.stack = scrubPii(obj.stack);
+    }
     return scrubbed;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   if (Array.isArray(obj)) return obj.map(item => scrubObject(item, visited));
+
+  // Only deep-scrub plain objects; leave class instances (Date, URL, Map, etc.) unchanged
+  if (Object.getPrototypeOf(obj) !== Object.prototype) return obj;
 
   const out: Record<string, unknown> = {};
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/packages/core/src/util/log-redaction.ts
+++ b/packages/core/src/util/log-redaction.ts
@@ -27,10 +27,7 @@ export function scrubObject(obj: unknown, seen?: WeakSet<object>): unknown {
 
   if (obj instanceof Error) {
     const record = obj as unknown as Record<string, unknown>;
-    const scrubbed = Object.create(Object.getPrototypeOf(obj) as object) as Record<
-      string,
-      unknown
-    >;
+    const scrubbed = Object.create(Object.getPrototypeOf(obj) as object) as Record<string, unknown>;
     for (const key of Object.keys(record)) {
       scrubbed[key] = scrubObject(record[key], visited);
     }

--- a/packages/core/src/util/log-redaction.ts
+++ b/packages/core/src/util/log-redaction.ts
@@ -17,49 +17,45 @@ export function scrubPii(value: string): string {
   return value.replace(phoneRe, scrubPhoneMatch).replace(emailRe, scrubEmailMatch);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function scrubObject(obj: any, seen?: WeakSet<object>): any {
+export function scrubObject(obj: unknown, seen?: WeakSet<object>): unknown {
   if (typeof obj === 'string') return scrubPii(obj);
   if (obj === null || typeof obj !== 'object') return obj;
 
   const visited = seen ?? new WeakSet<object>();
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   if (visited.has(obj)) return '[Circular]';
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   visited.add(obj);
 
   if (obj instanceof Error) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    const scrubbed = Object.create(Object.getPrototypeOf(obj)) as Error;
-    for (const key of Object.keys(obj)) {
-      (scrubbed as unknown as Record<string, unknown>)[key] = scrubObject(
-        (obj as unknown as Record<string, unknown>)[key],
-        visited
-      );
+    const record = obj as unknown as Record<string, unknown>;
+    const scrubbed = Object.create(Object.getPrototypeOf(obj) as object) as Record<
+      string,
+      unknown
+    >;
+    for (const key of Object.keys(record)) {
+      scrubbed[key] = scrubObject(record[key], visited);
     }
+    const result = scrubbed as unknown as Error;
     if (!Object.prototype.hasOwnProperty.call(scrubbed, 'message')) {
-      scrubbed.message = scrubPii(obj.message);
+      result.message = scrubPii(obj.message);
     }
     if (!Object.prototype.hasOwnProperty.call(scrubbed, 'name')) {
-      scrubbed.name = obj.name;
+      result.name = obj.name;
     }
     if (obj.stack && !Object.prototype.hasOwnProperty.call(scrubbed, 'stack')) {
-      scrubbed.stack = scrubPii(obj.stack);
+      result.stack = scrubPii(obj.stack);
     }
-    return scrubbed;
+    return result;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   if (Array.isArray(obj)) return obj.map(item => scrubObject(item, visited));
 
   // Only deep-scrub plain objects; leave class instances (Date, URL, Map, etc.) unchanged
   if (Object.getPrototypeOf(obj) !== Object.prototype) return obj;
 
+  const record = obj as Record<string, unknown>;
   const out: Record<string, unknown> = {};
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-  for (const key of Object.keys(obj)) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    out[key] = scrubObject(obj[key], visited);
+  for (const key of Object.keys(record)) {
+    out[key] = scrubObject(record[key], visited);
   }
   return out;
 }

--- a/packages/core/src/util/log-redaction.ts
+++ b/packages/core/src/util/log-redaction.ts
@@ -1,3 +1,36 @@
+const PHONE_RE = /\+\d[\d\-\s()]{6,}\d/g;
+const EMAIL_RE = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
+
+function scrubPhoneMatch(match: string): string {
+  const digits = match.replace(/[\s\-()]/g, '');
+  if (digits.length < 8) return '***';
+  return `${digits.slice(0, 2)}***${digits.slice(-4)}`;
+}
+
+function scrubEmailMatch(match: string): string {
+  const atIndex = match.indexOf('@');
+  if (atIndex <= 0) return '***';
+  return `${match[0]}***${match.slice(atIndex)}`;
+}
+
+export function scrubPii(value: string): string {
+  return value.replace(PHONE_RE, scrubPhoneMatch).replace(EMAIL_RE, scrubEmailMatch);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function scrubObject(obj: any): any {
+  if (typeof obj === 'string') return scrubPii(obj);
+  if (Array.isArray(obj)) return obj.map(scrubObject);
+  if (obj !== null && typeof obj === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(obj)) {
+      out[key] = scrubObject(obj[key]);
+    }
+    return out;
+  }
+  return obj;
+}
+
 export function maskPhone(phone: string): string {
   if (!phone || !phone.startsWith('+') || phone.length < 8) {
     return '***';

--- a/packages/core/src/util/log-redaction.ts
+++ b/packages/core/src/util/log-redaction.ts
@@ -1,6 +1,3 @@
-const PHONE_RE = /\+\d[\d\s()-]{6,}\d/g;
-const EMAIL_RE = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
-
 function scrubPhoneMatch(match: string): string {
   const digits = match.replace(/[\s\-()]/g, '');
   if (digits.length < 8) return '***';
@@ -14,23 +11,40 @@ function scrubEmailMatch(match: string): string {
 }
 
 export function scrubPii(value: string): string {
-  return value.replace(PHONE_RE, scrubPhoneMatch).replace(EMAIL_RE, scrubEmailMatch);
+  // Fresh RegExp each call — avoids lastIndex state bugs from the g flag
+  const phoneRe = /\+\d[\d\s()-]{6,}\d/g;
+  const emailRe = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
+  return value.replace(phoneRe, scrubPhoneMatch).replace(emailRe, scrubEmailMatch);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function scrubObject(obj: any): any {
+export function scrubObject(obj: any, seen?: WeakSet<object>): any {
   if (typeof obj === 'string') return scrubPii(obj);
-  if (Array.isArray(obj)) return obj.map(scrubObject);
-  if (obj !== null && typeof obj === 'object') {
-    const out: Record<string, unknown> = {};
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    for (const key of Object.keys(obj)) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      out[key] = scrubObject(obj[key]);
-    }
-    return out;
+  if (obj === null || typeof obj !== 'object') return obj;
+
+  const visited = seen ?? new WeakSet<object>();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  if (visited.has(obj)) return '[Circular]';
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  visited.add(obj);
+
+  if (obj instanceof Error) {
+    const scrubbed = new Error(scrubPii(obj.message));
+    scrubbed.name = obj.name;
+    if (obj.stack) scrubbed.stack = scrubPii(obj.stack);
+    return scrubbed;
   }
-  return obj;
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  if (Array.isArray(obj)) return obj.map(item => scrubObject(item, visited));
+
+  const out: Record<string, unknown> = {};
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  for (const key of Object.keys(obj)) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    out[key] = scrubObject(obj[key], visited);
+  }
+  return out;
 }
 
 export function maskPhone(phone: string): string {

--- a/packages/core/src/util/log-redaction.ts
+++ b/packages/core/src/util/log-redaction.ts
@@ -1,5 +1,5 @@
-const PHONE_RE = /\+\d[\d\-\s()]{6,}\d/g;
-const EMAIL_RE = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
+const PHONE_RE = /\+\d[\d\s()-]{6,}\d/g;
+const EMAIL_RE = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
 
 function scrubPhoneMatch(match: string): string {
   const digits = match.replace(/[\s\-()]/g, '');
@@ -23,7 +23,9 @@ export function scrubObject(obj: any): any {
   if (Array.isArray(obj)) return obj.map(scrubObject);
   if (obj !== null && typeof obj === 'object') {
     const out: Record<string, unknown> = {};
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     for (const key of Object.keys(obj)) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       out[key] = scrubObject(obj[key]);
     }
     return out;

--- a/packages/core/src/util/log-redaction.ts
+++ b/packages/core/src/util/log-redaction.ts
@@ -1,0 +1,22 @@
+export function maskPhone(phone: string): string {
+  if (!phone || !phone.startsWith('+') || phone.length < 8) {
+    return '***';
+  }
+  return `${phone.slice(0, 2)}***${phone.slice(-4)}`;
+}
+
+export function maskEmail(email: string): string {
+  const atIndex = email.indexOf('@');
+  if (atIndex <= 0) {
+    return '***';
+  }
+  return `${email[0]}***${email.slice(atIndex)}`;
+}
+
+export function maskAddress(address: string): string {
+  if (!address) return '***';
+  if (address.includes('@')) return maskEmail(address);
+  if (address.startsWith('+')) return maskPhone(address);
+  if (address.length <= 1) return '***';
+  return `${address[0]}***`;
+}

--- a/packages/core/src/util/log-redaction.ts
+++ b/packages/core/src/util/log-redaction.ts
@@ -32,8 +32,10 @@ export function scrubObject(obj: any, seen?: WeakSet<object>): any {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     const scrubbed = Object.create(Object.getPrototypeOf(obj)) as Error;
     for (const key of Object.keys(obj)) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      (scrubbed as Record<string, unknown>)[key] = scrubObject(obj[key], visited);
+      (scrubbed as unknown as Record<string, unknown>)[key] = scrubObject(
+        (obj as unknown as Record<string, unknown>)[key],
+        visited
+      );
     }
     if (!Object.prototype.hasOwnProperty.call(scrubbed, 'message')) {
       scrubbed.message = scrubPii(obj.message);

--- a/tests/pii.test.ts
+++ b/tests/pii.test.ts
@@ -7,7 +7,6 @@ import {
   scrubObject,
   SMSChannel,
   TAC,
-  ConversationClient,
 } from '@twilio/tac-core';
 import { createTestTAC } from './helpers/tac';
 import { Writable } from 'node:stream';
@@ -161,6 +160,38 @@ describe('PII masking', () => {
       expect(result.name).toBe('LookupError');
       expect(result.stack).toBeDefined();
       expect(result.stack).not.toContain('+15551234567');
+    });
+
+    it('should preserve Error subclass identity and custom properties', () => {
+      class ApiError extends Error {
+        code: number;
+        constructor(message: string, code: number) {
+          super(message);
+          this.name = 'ApiError';
+          this.code = code;
+        }
+      }
+      const err = new ApiError('User +15551234567 not found', 404);
+      const result = scrubObject(err);
+      expect(result).toBeInstanceOf(ApiError);
+      expect(result.message).toBe('User +1***4567 not found');
+      expect(result.code).toBe(404);
+    });
+
+    it('should pass through Date instances unchanged', () => {
+      const date = new Date('2024-01-01');
+      const obj = { timestamp: date, phone: '+15551234567' };
+      const result = scrubObject(obj);
+      expect(result.timestamp).toBe(date);
+      expect(result.phone).toBe('+1***4567');
+    });
+
+    it('should pass through class instances unchanged', () => {
+      const url = new URL('https://example.com');
+      const obj = { url, phone: '+15551234567' };
+      const result = scrubObject(obj);
+      expect(result.url).toBe(url);
+      expect(result.phone).toBe('+1***4567');
     });
   });
 

--- a/tests/pii.test.ts
+++ b/tests/pii.test.ts
@@ -3,11 +3,16 @@ import {
   maskPhone,
   maskEmail,
   maskAddress,
+  scrubPii,
+  scrubObject,
+  createLogger,
   SMSChannel,
   TAC,
   ConversationClient,
 } from '@twilio/tac-core';
 import { createTestTAC } from './helpers/tac';
+import { Writable } from 'node:stream';
+import pino from 'pino';
 
 describe('PII masking', () => {
   describe('maskPhone', () => {
@@ -80,6 +85,128 @@ describe('PII masking', () => {
 
     it('should return *** for single char', () => {
       expect(maskAddress('x')).toBe('***');
+    });
+  });
+
+  describe('scrubPii', () => {
+    it('should scrub a phone number from a string', () => {
+      expect(scrubPii('Call me at +15551234567 please')).toBe('Call me at +1***4567 please');
+    });
+
+    it('should scrub an email from a string', () => {
+      expect(scrubPii('Send to user@example.com now')).toBe('Send to u***@example.com now');
+    });
+
+    it('should scrub both phone and email in the same string', () => {
+      const input = 'Contact +15551234567 or user@example.com';
+      const result = scrubPii(input);
+      expect(result).not.toContain('+15551234567');
+      expect(result).not.toContain('user@example.com');
+      expect(result).toContain('+1***4567');
+      expect(result).toContain('u***@example.com');
+    });
+
+    it('should handle formatted phone numbers', () => {
+      expect(scrubPii('Call +1 (555) 123-4567')).not.toContain('555');
+    });
+
+    it('should leave non-PII strings unchanged', () => {
+      expect(scrubPii('Hello world')).toBe('Hello world');
+    });
+
+    it('should leave short numbers unchanged', () => {
+      expect(scrubPii('Code is +123')).toBe('Code is +123');
+    });
+  });
+
+  describe('scrubObject', () => {
+    it('should scrub phone numbers in nested objects', () => {
+      const obj = { user: { phone: '+15551234567', name: 'Alice' } };
+      const result = scrubObject(obj);
+      expect(result.user.phone).toBe('+1***4567');
+      expect(result.user.name).toBe('Alice');
+    });
+
+    it('should scrub emails in arrays', () => {
+      const obj = { addresses: ['user@example.com', 'admin@test.org'] };
+      const result = scrubObject(obj);
+      expect(result.addresses[0]).toBe('u***@example.com');
+      expect(result.addresses[1]).toBe('a***@test.org');
+    });
+
+    it('should pass through non-string primitives', () => {
+      expect(scrubObject(42)).toBe(42);
+      expect(scrubObject(true)).toBe(true);
+      expect(scrubObject(null)).toBe(null);
+    });
+
+    it('should scrub string values directly', () => {
+      expect(scrubObject('Call +15551234567')).toBe('Call +1***4567');
+    });
+  });
+
+  describe('PII safety filter (Pino hook)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function piiLogMethod(this: any, args: any[], method: pino.LogFn) {
+      const scrubbed = args.map(arg =>
+        typeof arg === 'string'
+          ? scrubObject(arg)
+          : typeof arg === 'object' && arg !== null
+            ? scrubObject(arg)
+            : arg
+      );
+      return method.apply(this, scrubbed as Parameters<pino.LogFn>);
+    }
+
+    function collectLogs(callback: (logger: pino.Logger) => void): string[] {
+      const lines: string[] = [];
+      const stream = new Writable({
+        write(chunk, _encoding, cb) {
+          lines.push(chunk.toString());
+          cb();
+        },
+      });
+      const logger = pino({ level: 'debug', hooks: { logMethod: piiLogMethod } }, stream);
+      callback(logger);
+      return lines;
+    }
+
+    it('should scrub phone numbers from log object fields', () => {
+      const lines = collectLogs(logger => {
+        logger.info({ phone: '+15551234567' }, 'test message');
+      });
+      expect(lines.length).toBe(1);
+      const parsed = JSON.parse(lines[0]);
+      expect(parsed.phone).toBe('+1***4567');
+      expect(lines[0]).not.toContain('+15551234567');
+    });
+
+    it('should scrub emails from log message strings', () => {
+      const lines = collectLogs(logger => {
+        logger.info('Contact user@example.com for help');
+      });
+      expect(lines.length).toBe(1);
+      expect(lines[0]).not.toContain('user@example.com');
+      expect(lines[0]).toContain('u***@example.com');
+    });
+
+    it('should scrub PII from nested objects', () => {
+      const lines = collectLogs(logger => {
+        logger.info({ data: { recipient: '+442071234567', email: 'alice@corp.co' } }, 'send');
+      });
+      const parsed = JSON.parse(lines[0]);
+      expect(parsed.data.recipient).toBe('+4***4567');
+      expect(parsed.data.email).toBe('a***@corp.co');
+    });
+
+    it('should not alter non-PII data', () => {
+      const lines = collectLogs(logger => {
+        logger.info({ conversation_id: 'CH123', count: 42 }, 'clean log');
+      });
+      const parsed = JSON.parse(lines[0]);
+      expect(parsed.conversation_id).toBe('CH123');
+      expect(parsed.count).toBe(42);
+      expect(parsed.msg).toBe('clean log');
     });
   });
 

--- a/tests/pii.test.ts
+++ b/tests/pii.test.ts
@@ -5,7 +5,6 @@ import {
   maskAddress,
   scrubPii,
   scrubObject,
-  createLogger,
   SMSChannel,
   TAC,
   ConversationClient,
@@ -143,6 +142,26 @@ describe('PII masking', () => {
     it('should scrub string values directly', () => {
       expect(scrubObject('Call +15551234567')).toBe('Call +1***4567');
     });
+
+    it('should handle circular references without stack overflow', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const obj: any = { phone: '+15551234567' };
+      obj.self = obj;
+      const result = scrubObject(obj);
+      expect(result.phone).toBe('+1***4567');
+      expect(result.self).toBe('[Circular]');
+    });
+
+    it('should preserve Error instances and scrub their messages', () => {
+      const err = new Error('Failed for +15551234567');
+      err.name = 'LookupError';
+      const result = scrubObject(err);
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toBe('Failed for +1***4567');
+      expect(result.name).toBe('LookupError');
+      expect(result.stack).toBeDefined();
+      expect(result.stack).not.toContain('+15551234567');
+    });
   });
 
   describe('PII safety filter (Pino hook)', () => {
@@ -207,6 +226,16 @@ describe('PII masking', () => {
       expect(parsed.conversation_id).toBe('CH123');
       expect(parsed.count).toBe(42);
       expect(parsed.msg).toBe('clean log');
+    });
+
+    it('should scrub Error messages while preserving stack', () => {
+      const lines = collectLogs(logger => {
+        logger.error({ err: new Error('No profile for +15551234567') }, 'lookup failed');
+      });
+      const parsed = JSON.parse(lines[0]);
+      expect(parsed.err.message).toBe('No profile for +1***4567');
+      expect(parsed.err.stack).toBeDefined();
+      expect(parsed.err.stack).not.toContain('+15551234567');
     });
   });
 

--- a/tests/pii.test.ts
+++ b/tests/pii.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  maskPhone,
+  maskEmail,
+  maskAddress,
+  SMSChannel,
+  TAC,
+  ConversationClient,
+} from '@twilio/tac-core';
+import { createTestTAC } from './helpers/tac';
+
+describe('PII masking', () => {
+  describe('maskPhone', () => {
+    it('should mask a US phone number', () => {
+      expect(maskPhone('+15551234567')).toBe('+1***4567');
+    });
+
+    it('should mask an international phone number', () => {
+      expect(maskPhone('+442071234567')).toBe('+4***4567');
+    });
+
+    it('should return *** for empty string', () => {
+      expect(maskPhone('')).toBe('***');
+    });
+
+    it('should return *** for too-short number', () => {
+      expect(maskPhone('+1234')).toBe('***');
+    });
+
+    it('should return *** for non-phone string', () => {
+      expect(maskPhone('hello')).toBe('***');
+    });
+
+    it('should handle boundary lengths', () => {
+      expect(maskPhone('+12345')).toBe('***');
+      expect(maskPhone('+123456')).toBe('***');
+      expect(maskPhone('+1234567')).toBe('+1***4567');
+      expect(maskPhone('+12345678')).toBe('+1***5678');
+    });
+  });
+
+  describe('maskEmail', () => {
+    it('should mask a standard email', () => {
+      expect(maskEmail('user@example.com')).toBe('u***@example.com');
+    });
+
+    it('should mask a short email', () => {
+      expect(maskEmail('a@b.co')).toBe('a***@b.co');
+    });
+
+    it('should return *** for empty string', () => {
+      expect(maskEmail('')).toBe('***');
+    });
+
+    it('should return *** for string without @', () => {
+      expect(maskEmail('not-an-email')).toBe('***');
+    });
+
+    it('should return *** for string starting with @', () => {
+      expect(maskEmail('@domain.com')).toBe('***');
+    });
+  });
+
+  describe('maskAddress', () => {
+    it('should auto-detect phone number', () => {
+      expect(maskAddress('+15551234567')).toBe('+1***4567');
+    });
+
+    it('should auto-detect email', () => {
+      expect(maskAddress('user@example.com')).toBe('u***@example.com');
+    });
+
+    it('should mask unknown format', () => {
+      expect(maskAddress('some-identity')).toBe('s***');
+    });
+
+    it('should return *** for empty string', () => {
+      expect(maskAddress('')).toBe('***');
+    });
+
+    it('should return *** for single char', () => {
+      expect(maskAddress('x')).toBe('***');
+    });
+  });
+
+  describe('log output masking', () => {
+    let tac: TAC;
+    let channel: SMSChannel;
+
+    const getTestConfig = () => ({
+      accountSid: 'ACtest123456789',
+      authToken: 'test_token_123',
+      apiKey: 'test_api_key',
+      apiSecret: 'test_api_token',
+      phoneNumber: '+15551234567',
+      conversationConfigurationId: 'conv_configuration_01kbjqhn79f0fvwfsxqzd5nqhd',
+    });
+
+    beforeEach(async () => {
+      tac = await createTestTAC(getTestConfig());
+      channel = new SMSChannel(tac);
+      tac.registerChannel(channel);
+      vi.spyOn(tac, 'retrieveMemory').mockResolvedValue(undefined as never);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should mask author address in communication.created logs', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const loggerInfoSpy = vi.spyOn((channel as any).logger, 'info');
+
+      await channel.processWebhook({
+        eventType: 'CONVERSATION_CREATED',
+        data: { conversationId: 'CHtest_pii' },
+      });
+
+      await channel.processWebhook({
+        eventType: 'COMMUNICATION_CREATED',
+        data: {
+          conversationId: 'CHtest_pii',
+          content: { type: 'TEXT', text: 'Hello, my SSN is 123-45-6789' },
+          author: { address: '+15559876543', channel: 'SMS' },
+        },
+      });
+
+      const communicationCreatedCall = loggerInfoSpy.mock.calls.find(
+        call => call[1] === 'Handling communication.created'
+      );
+      expect(communicationCreatedCall).toBeDefined();
+
+      const logContext = communicationCreatedCall![0] as Record<string, unknown>;
+
+      // Author address must be masked
+      expect(logContext.author).toBe('+1***6543');
+      // Raw phone number must NOT appear
+      expect(logContext.author).not.toBe('+15559876543');
+      // Message content must NOT be logged
+      expect(logContext).not.toHaveProperty('message');
+    });
+
+    it('should not include payload in webhook processing error context', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const loggerErrorSpy = vi.spyOn((channel as any).logger, 'error');
+
+      // Send a webhook that will fail (missing conversation ID for COMMUNICATION_CREATED)
+      await channel.processWebhook({
+        eventType: 'COMMUNICATION_CREATED',
+        data: {
+          content: { type: 'TEXT', text: 'secret message' },
+          author: { address: '+15559876543', channel: 'SMS' },
+        },
+      });
+
+      const errorCalls = loggerErrorSpy.mock.calls;
+      for (const call of errorCalls) {
+        const context = call[0] as Record<string, unknown>;
+        expect(context).not.toHaveProperty('payload');
+        // Ensure message body is not in the error context
+        if (typeof context === 'object') {
+          expect(JSON.stringify(context)).not.toContain('secret message');
+        }
+      }
+    });
+
+    it('should mask author address in profile lookup logs', async () => {
+      const tacWithMemory = await createTestTAC(getTestConfig());
+      const memoryClient = tacWithMemory.getMemoryClient();
+      vi.spyOn(memoryClient, 'lookupProfile').mockResolvedValue({ profiles: [] });
+
+      const conversationClient = tacWithMemory.getConversationClient();
+      vi.spyOn(conversationClient, 'listCommunications').mockResolvedValue([]);
+
+      const warnSpy = vi.spyOn(tacWithMemory.logger, 'warn');
+
+      await tacWithMemory.retrieveMemory({
+        conversationId: 'conv_test_123',
+        profileId: undefined,
+        channel: 'sms',
+        startedAt: new Date(),
+        authorInfo: { address: '+13175556789' },
+      });
+
+      // The "no profile found" error is caught and logged as a warning.
+      // Verify the logged error message contains the masked address.
+      const failedLookupCall = warnSpy.mock.calls.find(
+        call => typeof call[1] === 'string' && call[1].includes('falling back')
+      );
+      expect(failedLookupCall).toBeDefined();
+
+      const loggedError = (failedLookupCall![0] as Record<string, unknown>).err as Error;
+      expect(loggedError.message).toContain('+1***6789');
+      expect(loggedError.message).not.toContain('+13175556789');
+    });
+
+    it('should mask author in handle_message_ready logs', async () => {
+      const loggerDebugSpy = vi.spyOn(tac.logger, 'debug');
+
+      tac.onMessageReady(async () => {});
+
+      await channel.processWebhook({
+        eventType: 'CONVERSATION_CREATED',
+        data: { conversationId: 'CHtest_hmr' },
+      });
+
+      await channel.processWebhook({
+        eventType: 'COMMUNICATION_CREATED',
+        data: {
+          conversationId: 'CHtest_hmr',
+          content: { type: 'TEXT', text: 'test message' },
+          author: { address: '+15559876543', channel: 'SMS' },
+        },
+      });
+
+      await vi.waitFor(() => {
+        const messageReadyCall = loggerDebugSpy.mock.calls.find(
+          call => call[1] === 'Handling message ready'
+        );
+        expect(messageReadyCall).toBeDefined();
+
+        const logContext = messageReadyCall![0] as Record<string, unknown>;
+        expect(logContext.author).toBe('+1***6543');
+        expect(logContext.author).not.toBe('+15559876543');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `maskPhone`, `maskEmail`, `maskAddress` log-redaction utilities and export them from `@twilio/tac-core`
- Mask author/recipient address fields across all channels (SMS, Chat, Voice) and TAC orchestrator
- Remove full webhook payloads from debug/warn log statements
- Remove raw WebSocket message data and voice transcripts from error contexts
- Strip PII from `handleError` log output while preserving full context in customer `onError` callbacks
- Add defense-in-depth PII safety filter via Pino `hooks.logMethod` — regex-scrubs phone and email patterns from all log output before serialization, catching any PII a developer forgets to mask explicitly

## Type of Change

- [x] Bug fix
- [x] New feature

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

## Test plan

- [x] Unit tests for `maskPhone`, `maskEmail`, `maskAddress` (boundary lengths, edge cases)
- [x] Unit tests for `scrubPii` and `scrubObject` (phones, emails, nested objects, arrays, primitives)
- [x] Integration tests: Pino hook scrubs phone/email from log object fields, message strings, and nested objects
- [x] Integration test: intercept channel logger, verify `author` field is masked in `communication.created` log
- [x] Integration test: verify `payload` is not present in error context logs
- [x] Integration test: verify masked address in profile lookup warning log
- [x] Integration test: verify `author` is masked in `handle_message_ready` log

## SDK Parity

This is the **TypeScript SDK**. If this change affects shared functionality, ensure the [Python SDK](https://github.com/twilio/twilio-agent-connect-python) is updated as well.

- [ ] Change is TypeScript-specific (no Python update needed)
- [ ] Python SDK PR created: https://github.com/twilio/twilio-agent-connect-python/pull/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)