### PR TITLE
build(deps): Bump fastify from 5.8.4 to 5.8.5 in chat example

### DIFF
--- a/getting_started/examples/chat/package-lock.json
+++ b/getting_started/examples/chat/package-lock.json
@@ -27,7 +27,7 @@
       "dependencies": {
         "@fastify/formbody": "^8.0.2",
         "@fastify/websocket": "^11.2.0",
-        "axios": "^1.15.0",
+        "axios": "^1.15.1",
         "axios-retry": "^4.5.0",
         "dotenv": "^16.4.7",
         "fastify": "^5.8.5",
@@ -1208,9 +1208,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.8.4",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.4.tgz",
-      "integrity": "sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==",
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
+      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Bumps fastify from 5.8.4 to 5.8.5 in the `getting_started/examples/chat` example to fix [GHSA-247c-9743-5963](https://github.com/advisories/GHSA-247c-9743-5963) (body schema validation bypass via leading space in Content-Type header).

Closes #6 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated
- [ ] Tested E2E

## SDK Parity

This is the **TypeScript SDK**. If this change affects shared functionality, ensure the [Python SDK](https://github.com/twilio/twilio-agent-connect-python) is updated as well.

- [x] Change is TypeScript-specific (no Python update needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)