### PR TITLE
feat(core): Add voice-only mode (ConversationRelay)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,11 +47,11 @@ getting_started/  # Example apps (OpenAI integration)
 
 - **TAC class** (`packages/core/src/lib/tac.ts`): Central orchestrator managing config, channels, callbacks, and API clients
 - **Channel abstraction** (`packages/core/src/channels/base.ts`): `BaseChannel` abstract base class extended by `SMSChannel` (webhooks/TwiML) and `VoiceChannel` (WebSocket)
-- **Voice channel initialization**: VoiceChannel waits for the first prompt message to initialize the conversation (fetches from ConversationRelay using `callSid`, extracts `profileId` from participants, then starts local session)
+- **Voice channel initialization**: In orchestrated mode, VoiceChannel waits for the first prompt message to initialize the conversation (polls Conversation Orchestrator using `callSid`, extracts `profileId` from participants, then starts local session). In voice-only mode (no `conversationConfigurationId`), uses `callSid` directly as the conversation ID without polling.
 - **Callback pattern**: Simple callbacks (`onMessageReady`, `onInterrupt`, `onConversationEnded`) instead of EventEmitter
 - **Callback responses**: `onMessageReady` callbacks return `string` (auto-sent), `void`/`null` (manual `channel.sendResponse()`)
 - **Tool system** (`packages/tools/src/lib/builder.ts`): `defineTool()` with JSON schema; supports conversion to OpenAI and Anthropic formats
-- **Config via Zod** (`packages/core/src/lib/config.ts`): `TACConfig.fromEnv()` validates env vars
+- **Config via Zod** (`packages/core/src/lib/config.ts`): `TACConfig.fromEnv()` validates env vars. Only `accountSid`, `authToken`, and `phoneNumber` are required; `conversationConfigurationId`, `apiKey`, and `apiSecret` are optional (voice-only mode when omitted)
 - **API client architecture** (`packages/core/src/clients/`):
   - `BaseClient` abstract class provides common HTTP functionality using **axios**
   - All API clients (Memory, Conversation, Knowledge) inherit from BaseClient

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ getting_started/  # Example apps (OpenAI integration)
 - **Callback pattern**: Simple callbacks (`onMessageReady`, `onInterrupt`, `onConversationEnded`) instead of EventEmitter
 - **Callback responses**: `onMessageReady` callbacks return `string` (auto-sent), `void`/`null` (manual `channel.sendResponse()`)
 - **Tool system** (`packages/tools/src/lib/builder.ts`): `defineTool()` with JSON schema; supports conversion to OpenAI and Anthropic formats
-- **Config via Zod** (`packages/core/src/lib/config.ts`): `TACConfig.fromEnv()` validates env vars. Only `accountSid`, `authToken`, and `phoneNumber` are required; `conversationConfigurationId`, `apiKey`, and `apiSecret` are optional (voice-only mode when omitted)
+- **Config via Zod** (`packages/core/src/lib/config.ts`): `TACConfig.fromEnv()` validates env vars. Only `accountSid`, `authToken`, `apiKey`, `apiSecret`, and `phoneNumber` are required; `conversationConfigurationId` is optional (voice-only mode when omitted)
 - **API client architecture** (`packages/core/src/clients/`):
   - `BaseClient` abstract class provides common HTTP functionality using **axios**
   - All API clients (Memory, Conversation, Knowledge) inherit from BaseClient

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ For detailed architecture and advanced usage, see [CLAUDE.md](.claude/CLAUDE.md)
 **Examples & Guides:**
 - **[Getting Started Guide](getting_started/)** - Examples and comprehensive documentation
 - **[OpenAI SDK Example](getting_started/examples/openai/)** - Complete multi-channel example with Voice and SMS
+- **[Voice-Only (Relay) Example](getting_started/examples/relay-only/)** - Voice-only mode with ConversationRelay and streaming
 - More examples coming soon
 
 **Documentation:**

--- a/getting_started/examples/relay-only/.env.example
+++ b/getting_started/examples/relay-only/.env.example
@@ -1,0 +1,7 @@
+# Required for relay-only mode
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_AUTH_TOKEN=your_auth_token
+TWILIO_PHONE_NUMBER=+15551234567
+
+# OpenAI API Key (for the example agent)
+OPENAI_API_KEY=sk-...

--- a/getting_started/examples/relay-only/.env.example
+++ b/getting_started/examples/relay-only/.env.example
@@ -1,6 +1,8 @@
-# Required for relay-only mode
+# Required Twilio credentials
 TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_AUTH_TOKEN=your_auth_token
+TWILIO_API_KEY=SKxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_API_SECRET=your_api_secret
 TWILIO_PHONE_NUMBER=+15551234567
 
 # OpenAI API Key (for the example agent)

--- a/getting_started/examples/relay-only/package.json
+++ b/getting_started/examples/relay-only/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tac-example-relay-only",
   "version": "1.0.0",
-  "description": "ConversationRelay-only example (no Conversation Orchestrator) for Twilio Agent Connect",
+  "description": "Voice-only mode example for Twilio Agent Connect",
   "private": true,
   "type": "module",
   "scripts": {

--- a/getting_started/examples/relay-only/package.json
+++ b/getting_started/examples/relay-only/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "tac-example-relay-only",
+  "version": "1.0.0",
+  "description": "ConversationRelay-only example (no Conversation Orchestrator) for Twilio Agent Connect",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "twilio-agent-connect": "file:../../..",
+    "dotenv": "^16.4.5",
+    "@openai/agents": "^0.8.5"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/getting_started/examples/relay-only/src/index.ts
+++ b/getting_started/examples/relay-only/src/index.ts
@@ -5,7 +5,7 @@
  * This is the simplest way to get started — only requires Twilio account
  * credentials and a phone number. Conversation state is managed locally.
  *
- * Required env vars: TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER
+ * Required env vars: TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_API_KEY, TWILIO_API_SECRET, TWILIO_PHONE_NUMBER
  */
 
 import { config } from 'dotenv';

--- a/getting_started/examples/relay-only/src/index.ts
+++ b/getting_started/examples/relay-only/src/index.ts
@@ -1,0 +1,104 @@
+/**
+ * Example: Voice-Only Mode (ConversationRelay)
+ *
+ * Demonstrates TAC in voice-only mode using ConversationRelay with streaming.
+ * This is the simplest way to get started — only requires Twilio account
+ * credentials and a phone number. Conversation state is managed locally.
+ *
+ * Required env vars: TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER
+ */
+
+import { config } from 'dotenv';
+import { Agent, run } from '@openai/agents';
+import type { AgentInputItem } from '@openai/agents';
+import { TAC, TACConfig, VoiceChannel, TACServer } from 'twilio-agent-connect';
+
+config({ path: '../.env' });
+
+const agent = new Agent({
+  name: 'relay-only-agent',
+  instructions: 'You are a helpful assistant. Keep responses concise for voice.',
+  model: 'gpt-5.4-mini',
+});
+
+const tac = await TAC.create({ config: TACConfig.fromEnv() });
+const voiceChannel = new VoiceChannel(tac);
+
+tac.registerChannel(voiceChannel);
+
+const conversationHistory: Record<string, AgentInputItem[]> = {};
+
+tac.onMessageReady(async ({ conversationId, message, abortSignal }) => {
+  const convId = conversationId as string;
+
+  if (!conversationHistory[convId]) {
+    conversationHistory[convId] = [];
+  }
+
+  conversationHistory[convId].push({
+    type: 'message',
+    role: 'user',
+    content: message,
+  });
+
+  if (abortSignal?.aborted) return;
+
+  const streamedResult = await run(agent, conversationHistory[convId], {
+    stream: true,
+    signal: abortSignal,
+  });
+
+  async function* tokenStream() {
+    for await (const chunk of streamedResult.toTextStream()) {
+      yield chunk;
+    }
+  }
+
+  const fullResponse = await voiceChannel.sendStreamingResponse(
+    conversationId,
+    tokenStream(),
+    abortSignal !== undefined ? { signal: abortSignal } : undefined
+  );
+
+  await streamedResult.completed;
+
+  if (!abortSignal?.aborted) {
+    conversationHistory[convId].push({
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: fullResponse }],
+    });
+  }
+});
+
+tac.onInterrupt(({ conversationId, utteranceUntilInterrupt }) => {
+  const convId = conversationId as string;
+  const history = conversationHistory[convId];
+  if (!history || utteranceUntilInterrupt === undefined) return;
+
+  for (let i = history.length - 1; i >= 0; i--) {
+    const item = history[i];
+    if (item?.type === 'message' && item.role === 'assistant') {
+      history[i] = {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: utteranceUntilInterrupt }],
+      };
+      history.splice(i + 1);
+      break;
+    }
+  }
+});
+
+tac.onConversationEnded(({ session }) => {
+  const convId = session.conversationId as string;
+  delete conversationHistory[convId];
+  console.log(`Conversation ${convId} ended, history cleaned up`);
+});
+
+const server = new TACServer(tac, {
+  voice: { host: '0.0.0.0', port: 8000 },
+  development: true,
+});
+
+await server.start();

--- a/getting_started/examples/relay-only/src/index.ts
+++ b/getting_started/examples/relay-only/src/index.ts
@@ -22,6 +22,13 @@ const agent = new Agent({
 });
 
 const tac = await TAC.create({ config: TACConfig.fromEnv() });
+
+if (tac.isOrchestratorEnabled()) {
+  throw new Error(
+    'This example expects voice-only mode — unset TWILIO_CONVERSATION_CONFIGURATION_ID.'
+  );
+}
+
 const voiceChannel = new VoiceChannel(tac);
 
 tac.registerChannel(voiceChannel);

--- a/getting_started/examples/relay-only/tsconfig.json
+++ b/getting_started/examples/relay-only/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/core/src/channels/base.ts
+++ b/packages/core/src/channels/base.ts
@@ -23,7 +23,7 @@ export abstract class BaseChannel {
   protected readonly tac: TAC;
   protected readonly config: TACConfig;
   protected readonly logger: Logger;
-  protected readonly conversationClient: ConversationClient;
+  protected readonly conversationClient: ConversationClient | null;
   protected readonly activeConversations: Map<ConversationId, ConversationSession>;
   protected readonly callbacks: BaseChannelEvents;
 

--- a/packages/core/src/channels/messaging.ts
+++ b/packages/core/src/channels/messaging.ts
@@ -10,6 +10,7 @@ import {
   isProfileId,
 } from '../types/index';
 import { BaseChannel, BaseChannelEvents } from './base';
+import { ConversationClient } from '../clients/conversation';
 import type { TAC } from '../lib/tac';
 import { maskAddress } from '../util/log-redaction';
 
@@ -80,12 +81,21 @@ export interface MessagingChannelEvents extends BaseChannelEvents {
  * (SMS and Chat) that use the Conversations Service webhooks.
  */
 export abstract class MessagingChannel extends BaseChannel {
+  protected override readonly conversationClient: ConversationClient;
   protected readonly messagingCallbacks: MessagingChannelEvents;
   private readonly processedTokens = new Set<string>();
   private readonly maxTrackedTokens: number;
 
   constructor(tac: TAC, config?: MessagingChannelConfig) {
     super(tac);
+    if (!tac.isOrchestratorEnabled()) {
+      throw new Error(
+        'Messaging channels require conversationConfigurationId to be configured. ' +
+          'Voice-only mode does not support SMS or Chat channels.'
+      );
+    }
+    // Safe: orchestrator is enabled so conversationClient is guaranteed non-null
+    this.conversationClient = tac.getConversationClient() as ConversationClient;
     this.messagingCallbacks = {};
     const capacity = config?.dedupCapacity ?? DEFAULT_DEDUP_CAPACITY;
     if (capacity < 1 || !Number.isInteger(capacity)) {

--- a/packages/core/src/channels/voice.ts
+++ b/packages/core/src/channels/voice.ts
@@ -82,13 +82,9 @@ export class VoiceChannel extends BaseChannel {
 
   private getTwilioClient(): ReturnType<typeof Twilio> {
     if (!this.twilioClient) {
-      if (this.config.apiKey && this.config.apiSecret) {
-        this.twilioClient = Twilio(this.config.apiKey, this.config.apiSecret, {
-          accountSid: this.config.accountSid,
-        });
-      } else {
-        this.twilioClient = Twilio(this.config.accountSid, this.config.authToken);
-      }
+      this.twilioClient = Twilio(this.config.apiKey, this.config.apiSecret, {
+        accountSid: this.config.accountSid,
+      });
     }
     return this.twilioClient;
   }
@@ -702,6 +698,14 @@ export class VoiceChannel extends BaseChannel {
       { call_sid: payload.CallSid, call_status: payload.CallStatus },
       'ConversationRelay callback received'
     );
+
+    if (payload.AccountSid !== this.config.accountSid) {
+      this.logger.warn(
+        { expected: this.config.accountSid, received: payload.AccountSid },
+        'ConversationRelay callback AccountSid mismatch, ignoring'
+      );
+      return { status: 403, content: 'Forbidden', contentType: 'text/plain' };
+    }
 
     if (payload.CallStatus === 'completed') {
       const conversationId = this.callSidToConversationId.get(payload.CallSid);

--- a/packages/core/src/channels/voice.ts
+++ b/packages/core/src/channels/voice.ts
@@ -345,6 +345,7 @@ export class VoiceChannel extends BaseChannel {
       }
       if (callSid) {
         this.initializationRetries.delete(callSid);
+        this.callSidToConversationId.delete(callSid);
       }
     });
 

--- a/packages/core/src/channels/voice.ts
+++ b/packages/core/src/channels/voice.ts
@@ -66,6 +66,7 @@ export class VoiceChannel extends BaseChannel {
   private readonly streamTasks: Map<ConversationId, StreamTask>;
   private readonly promptQueues: Map<ConversationId, Promise<void>>;
   private readonly initializationRetries: Map<string, number>;
+  private readonly callSidToConversationId: Map<string, ConversationId>;
   private readonly MAX_INITIALIZATION_RETRIES = 3;
   private twilioClient: ReturnType<typeof Twilio> | undefined;
 
@@ -76,13 +77,18 @@ export class VoiceChannel extends BaseChannel {
     this.streamTasks = new Map();
     this.promptQueues = new Map();
     this.initializationRetries = new Map();
+    this.callSidToConversationId = new Map();
   }
 
   private getTwilioClient(): ReturnType<typeof Twilio> {
     if (!this.twilioClient) {
-      this.twilioClient = Twilio(this.config.apiKey, this.config.apiSecret, {
-        accountSid: this.config.accountSid,
-      });
+      if (this.config.apiKey && this.config.apiSecret) {
+        this.twilioClient = Twilio(this.config.apiKey, this.config.apiSecret, {
+          accountSid: this.config.accountSid,
+        });
+      } else {
+        this.twilioClient = Twilio(this.config.accountSid, this.config.authToken);
+      }
     }
     return this.twilioClient;
   }
@@ -197,56 +203,73 @@ export class VoiceChannel extends BaseChannel {
                     );
                   }
 
-                  // Poll for the conversation — CO may not have created it yet
-                  const POLL_ATTEMPTS = 5;
-                  const POLL_DELAY_MS = 500;
-                  let conversations: Awaited<
-                    ReturnType<typeof this.conversationClient.listConversations>
-                  > = [];
+                  if (!this.tac.isOrchestratorEnabled()) {
+                    // Voice-only mode: use callSid as conversationId directly
+                    conversationId = callSid as ConversationId;
+                    this.webSocketConnections.set(conversationId, ws);
+                    this.callSidToConversationId.set(callSid, conversationId);
+                    const session = this.startConversation(conversationId);
 
-                  for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
-                    conversations = await this.conversationClient.listConversations({
-                      channelId: callSid,
-                    });
-                    if (conversations.length === 1) break;
-                    if (attempt < POLL_ATTEMPTS - 1) {
-                      this.logger.debug(
-                        { call_sid: callSid, attempt: attempt + 1, found: conversations.length },
-                        'Conversation not ready yet, polling again'
-                      );
-                      await new Promise(resolve => setTimeout(resolve, POLL_DELAY_MS));
+                    if (fromNumber) {
+                      session.authorInfo = { address: fromNumber };
                     }
-                  }
+                  } else {
+                    // Orchestrated mode: poll for conversation created by CO
+                    if (!this.conversationClient) {
+                      throw new Error('Conversation client is required in orchestrated mode');
+                    }
 
-                  if (conversations.length !== 1) {
-                    throw new Error(
-                      `Expected exactly 1 conversation for callSid ${callSid}, ` +
-                        `but found ${conversations.length} after ${POLL_ATTEMPTS} attempts`
-                    );
-                  }
+                    const POLL_ATTEMPTS = 5;
+                    const POLL_DELAY_MS = 500;
+                    let conversations: Awaited<
+                      ReturnType<typeof this.conversationClient.listConversations>
+                    > = [];
 
-                  const conversation = conversations[0]!;
-                  conversationId = conversation.id as ConversationId;
+                    for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
+                      conversations = await this.conversationClient.listConversations({
+                        channelId: callSid,
+                      });
+                      if (conversations.length === 1) break;
+                      if (attempt < POLL_ATTEMPTS - 1) {
+                        this.logger.debug(
+                          { call_sid: callSid, attempt: attempt + 1, found: conversations.length },
+                          'Conversation not ready yet, polling again'
+                        );
+                        await new Promise(resolve => setTimeout(resolve, POLL_DELAY_MS));
+                      }
+                    }
 
-                  const participants =
-                    await this.conversationClient.listParticipants(conversationId);
+                    if (conversations.length !== 1) {
+                      throw new Error(
+                        `Expected exactly 1 conversation for callSid ${callSid}, ` +
+                          `but found ${conversations.length} after ${POLL_ATTEMPTS} attempts`
+                      );
+                    }
 
-                  const customerParticipant = participants.find(p => p.type === 'CUSTOMER');
-                  const customerAddress =
-                    customerParticipant?.addresses?.find(a => a.channel === 'VOICE')?.address ??
-                    fromNumber ??
-                    undefined;
-                  const profileId: ProfileId | undefined = customerParticipant?.profileId
-                    ? (customerParticipant.profileId as ProfileId)
-                    : undefined;
+                    const conversation = conversations[0]!;
+                    conversationId = conversation.id as ConversationId;
 
-                  this.webSocketConnections.set(conversationId, ws);
-                  const session = this.startConversation(conversationId, profileId);
+                    const participants =
+                      await this.conversationClient.listParticipants(conversationId);
 
-                  if (customerAddress) {
-                    session.authorInfo = {
-                      address: customerAddress,
-                    };
+                    const customerParticipant = participants.find(p => p.type === 'CUSTOMER');
+                    const customerAddress =
+                      customerParticipant?.addresses?.find(a => a.channel === 'VOICE')?.address ??
+                      fromNumber ??
+                      undefined;
+                    const profileId: ProfileId | undefined = customerParticipant?.profileId
+                      ? (customerParticipant.profileId as ProfileId)
+                      : undefined;
+
+                    this.webSocketConnections.set(conversationId, ws);
+                    this.callSidToConversationId.set(callSid, conversationId);
+                    const session = this.startConversation(conversationId, profileId);
+
+                    if (customerAddress) {
+                      session.authorInfo = {
+                        address: customerAddress,
+                      };
+                    }
                   }
 
                   if (this.voiceCallbacks.onWebSocketConnected) {
@@ -580,12 +603,14 @@ export class VoiceChannel extends BaseChannel {
     conversationRelayConfig: ConversationRelayConfig;
   }): string {
     const { actionUrl, conversationRelayConfig } = options;
+    const conversationConfiguration = this.tac.isOrchestratorEnabled()
+      ? (conversationRelayConfig.conversationConfiguration ??
+        this.config.conversationConfigurationId)
+      : undefined;
     return this.connectConversationRelay(
       {
         ...conversationRelayConfig,
-        conversationConfiguration:
-          conversationRelayConfig.conversationConfiguration ??
-          this.config.conversationConfigurationId,
+        ...(conversationConfiguration !== undefined && { conversationConfiguration }),
       },
       actionUrl ? { actionUrl } : undefined
     );
@@ -620,13 +645,14 @@ export class VoiceChannel extends BaseChannel {
     );
 
     try {
-      // Generate TwiML — CO creates conversation via conversationConfiguration
+      const conversationConfiguration = this.tac.isOrchestratorEnabled()
+        ? (validated.conversationRelayConfig.conversationConfiguration ??
+          this.config.conversationConfigurationId)
+        : undefined;
       const twiml = this.connectConversationRelay(
         {
           ...validated.conversationRelayConfig,
-          conversationConfiguration:
-            validated.conversationRelayConfig.conversationConfiguration ??
-            this.config.conversationConfigurationId,
+          ...(conversationConfiguration !== undefined && { conversationConfiguration }),
         },
         {
           ...(validated.actionUrl ? { actionUrl: validated.actionUrl } : {}),
@@ -669,7 +695,7 @@ export class VoiceChannel extends BaseChannel {
    * @param payload - Callback payload from Twilio
    * @returns Response with status, content, and content type
    */
-  public handleConversationRelayCallback(
+  public async handleConversationRelayCallback(
     payload: ConversationRelayCallbackPayload
   ): Promise<{ status: number; content: string; contentType: string }> {
     this.logger.debug(
@@ -677,7 +703,15 @@ export class VoiceChannel extends BaseChannel {
       'ConversationRelay callback received'
     );
 
-    return Promise.resolve({ status: 200, content: 'OK', contentType: 'text/plain' });
+    if (payload.CallStatus === 'completed') {
+      const conversationId = this.callSidToConversationId.get(payload.CallSid);
+      if (conversationId) {
+        this.callSidToConversationId.delete(payload.CallSid);
+        await this.endConversation(conversationId);
+      }
+    }
+
+    return { status: 200, content: 'OK', contentType: 'text/plain' };
   }
 
   // =========================================================================
@@ -840,6 +874,7 @@ export class VoiceChannel extends BaseChannel {
     this.webSocketConnections.clear();
     this.promptQueues.clear();
     this.initializationRetries.clear();
+    this.callSidToConversationId.clear();
     super.shutdown();
   }
 }

--- a/packages/core/src/clients/base.ts
+++ b/packages/core/src/clients/base.ts
@@ -29,10 +29,6 @@ export abstract class BaseClient {
     this.baseUrl = baseUrl;
     this.logger = logger || createLogger({ name: this.constructor.name });
 
-    if (!config.apiKey || !config.apiSecret) {
-      throw new Error('apiKey and apiSecret are required for API client authentication');
-    }
-
     // Create Authorization header for Basic Auth
     const authHeader =
       'Basic ' + Buffer.from(`${config.apiKey}:${config.apiSecret}`).toString('base64');

--- a/packages/core/src/clients/base.ts
+++ b/packages/core/src/clients/base.ts
@@ -29,6 +29,10 @@ export abstract class BaseClient {
     this.baseUrl = baseUrl;
     this.logger = logger || createLogger({ name: this.constructor.name });
 
+    if (!config.apiKey || !config.apiSecret) {
+      throw new Error('apiKey and apiSecret are required for API client authentication');
+    }
+
     // Create Authorization header for Basic Auth
     const authHeader =
       'Basic ' + Buffer.from(`${config.apiKey}:${config.apiSecret}`).toString('base64');

--- a/packages/core/src/clients/conversation.ts
+++ b/packages/core/src/clients/conversation.ts
@@ -33,6 +33,9 @@ export class ConversationClient extends BaseClient {
       ? `https://conversations.${config.region}.twilio.com`
       : 'https://conversations.twilio.com';
     super(baseUrl, config, logger);
+    if (!config.conversationConfigurationId) {
+      throw new Error('conversationConfigurationId is required to create ConversationClient');
+    }
     this.conversationConfigurationId = config.conversationConfigurationId;
   }
 

--- a/packages/core/src/lib/config.ts
+++ b/packages/core/src/lib/config.ts
@@ -19,8 +19,8 @@ import { z } from 'zod';
 export class TACConfig {
   public readonly accountSid: string;
   public readonly authToken: string;
-  public readonly apiKey?: string;
-  public readonly apiSecret?: string;
+  public readonly apiKey: string;
+  public readonly apiSecret: string;
   public readonly phoneNumber: string;
   public readonly memoryConfig: TACConfigData['memoryConfig'];
   public readonly conversationConfigurationId?: string;
@@ -45,15 +45,11 @@ export class TACConfig {
     // Assign all properties
     this.accountSid = validatedConfig.accountSid;
     this.authToken = validatedConfig.authToken;
+    this.apiKey = validatedConfig.apiKey;
+    this.apiSecret = validatedConfig.apiSecret;
     this.phoneNumber = validatedConfig.phoneNumber;
     // Assign the validated memory config directly; schema parsing already validates shape and applies defaults
     this.memoryConfig = validatedConfig.memoryConfig;
-    if (validatedConfig.apiKey) {
-      this.apiKey = validatedConfig.apiKey;
-    }
-    if (validatedConfig.apiSecret) {
-      this.apiSecret = validatedConfig.apiSecret;
-    }
     if (validatedConfig.conversationConfigurationId) {
       this.conversationConfigurationId = validatedConfig.conversationConfigurationId;
     }
@@ -118,6 +114,8 @@ export class TACConfig {
     const requiredVars = [
       { key: EnvironmentVariables.TWILIO_ACCOUNT_SID, name: 'TWILIO_ACCOUNT_SID' },
       { key: EnvironmentVariables.TWILIO_AUTH_TOKEN, name: 'TWILIO_AUTH_TOKEN' },
+      { key: EnvironmentVariables.TWILIO_API_KEY, name: 'TWILIO_API_KEY' },
+      { key: EnvironmentVariables.TWILIO_API_SECRET, name: 'TWILIO_API_SECRET' },
       { key: EnvironmentVariables.TWILIO_PHONE_NUMBER, name: 'TWILIO_PHONE_NUMBER' },
     ];
 
@@ -193,8 +191,8 @@ export class TACConfig {
     const rawConfig = {
       accountSid: process.env[EnvironmentVariables.TWILIO_ACCOUNT_SID]!,
       authToken: process.env[EnvironmentVariables.TWILIO_AUTH_TOKEN]!,
-      apiKey: process.env[EnvironmentVariables.TWILIO_API_KEY] || undefined,
-      apiSecret: process.env[EnvironmentVariables.TWILIO_API_SECRET] || undefined,
+      apiKey: process.env[EnvironmentVariables.TWILIO_API_KEY]!,
+      apiSecret: process.env[EnvironmentVariables.TWILIO_API_SECRET]!,
       phoneNumber: process.env[EnvironmentVariables.TWILIO_PHONE_NUMBER]!,
       memoryConfig: {
         traitGroups,

--- a/packages/core/src/lib/config.ts
+++ b/packages/core/src/lib/config.ts
@@ -19,11 +19,11 @@ import { z } from 'zod';
 export class TACConfig {
   public readonly accountSid: string;
   public readonly authToken: string;
-  public readonly apiKey: string;
-  public readonly apiSecret: string;
+  public readonly apiKey?: string;
+  public readonly apiSecret?: string;
   public readonly phoneNumber: string;
   public readonly memoryConfig: TACConfigData['memoryConfig'];
-  public readonly conversationConfigurationId: string;
+  public readonly conversationConfigurationId?: string;
   public readonly voicePublicDomain?: string;
   public readonly cintelConfigurationId?: string;
   public readonly cintelObservationOperatorSid?: string;
@@ -45,12 +45,18 @@ export class TACConfig {
     // Assign all properties
     this.accountSid = validatedConfig.accountSid;
     this.authToken = validatedConfig.authToken;
-    this.apiKey = validatedConfig.apiKey;
-    this.apiSecret = validatedConfig.apiSecret;
     this.phoneNumber = validatedConfig.phoneNumber;
     // Assign the validated memory config directly; schema parsing already validates shape and applies defaults
     this.memoryConfig = validatedConfig.memoryConfig;
-    this.conversationConfigurationId = validatedConfig.conversationConfigurationId;
+    if (validatedConfig.apiKey) {
+      this.apiKey = validatedConfig.apiKey;
+    }
+    if (validatedConfig.apiSecret) {
+      this.apiSecret = validatedConfig.apiSecret;
+    }
+    if (validatedConfig.conversationConfigurationId) {
+      this.conversationConfigurationId = validatedConfig.conversationConfigurationId;
+    }
     if (validatedConfig.voicePublicDomain) {
       this.voicePublicDomain = validatedConfig.voicePublicDomain;
     }
@@ -77,9 +83,11 @@ export class TACConfig {
    * Required environment variables:
    * - TWILIO_ACCOUNT_SID: Twilio Account SID
    * - TWILIO_AUTH_TOKEN: Twilio Auth Token for API authentication
+   * - TWILIO_PHONE_NUMBER: Phone number for voice and SMS channels
+   *
+   * Required for orchestrated mode (when TWILIO_CONVERSATION_CONFIGURATION_ID is set):
    * - TWILIO_API_KEY: Twilio API Key SID (starts with SK)
    * - TWILIO_API_SECRET: Twilio API Secret for API Key authentication
-   * - TWILIO_PHONE_NUMBER: Phone number for voice and SMS channels
    * - TWILIO_CONVERSATION_CONFIGURATION_ID: Conversation Orchestrator configuration ID
    *
    * Optional environment variables:
@@ -110,13 +118,7 @@ export class TACConfig {
     const requiredVars = [
       { key: EnvironmentVariables.TWILIO_ACCOUNT_SID, name: 'TWILIO_ACCOUNT_SID' },
       { key: EnvironmentVariables.TWILIO_AUTH_TOKEN, name: 'TWILIO_AUTH_TOKEN' },
-      { key: EnvironmentVariables.TWILIO_API_KEY, name: 'TWILIO_API_KEY' },
-      { key: EnvironmentVariables.TWILIO_API_SECRET, name: 'TWILIO_API_SECRET' },
       { key: EnvironmentVariables.TWILIO_PHONE_NUMBER, name: 'TWILIO_PHONE_NUMBER' },
-      {
-        key: EnvironmentVariables.TWILIO_CONVERSATION_CONFIGURATION_ID,
-        name: 'TWILIO_CONVERSATION_CONFIGURATION_ID',
-      },
     ];
 
     // Throw error for missing required variables (like Python's KeyError)
@@ -191,8 +193,8 @@ export class TACConfig {
     const rawConfig = {
       accountSid: process.env[EnvironmentVariables.TWILIO_ACCOUNT_SID]!,
       authToken: process.env[EnvironmentVariables.TWILIO_AUTH_TOKEN]!,
-      apiKey: process.env[EnvironmentVariables.TWILIO_API_KEY]!,
-      apiSecret: process.env[EnvironmentVariables.TWILIO_API_SECRET]!,
+      apiKey: process.env[EnvironmentVariables.TWILIO_API_KEY] || undefined,
+      apiSecret: process.env[EnvironmentVariables.TWILIO_API_SECRET] || undefined,
       phoneNumber: process.env[EnvironmentVariables.TWILIO_PHONE_NUMBER]!,
       memoryConfig: {
         traitGroups,
@@ -222,7 +224,7 @@ export class TACConfig {
         ),
       },
       conversationConfigurationId:
-        process.env[EnvironmentVariables.TWILIO_CONVERSATION_CONFIGURATION_ID]!,
+        process.env[EnvironmentVariables.TWILIO_CONVERSATION_CONFIGURATION_ID] || undefined,
       voicePublicDomain: process.env[EnvironmentVariables.VOICE_PUBLIC_DOMAIN],
       cintelConfigurationId: process.env[EnvironmentVariables.TWILIO_TAC_CI_CONFIGURATION_ID],
       cintelObservationOperatorSid:
@@ -234,6 +236,14 @@ export class TACConfig {
     };
 
     return new TACConfig(rawConfig);
+  }
+
+  /**
+   * Whether Conversation Orchestrator is configured.
+   * Returns false in voice-only mode (no conversationConfigurationId).
+   */
+  public isOrchestratorEnabled(): boolean {
+    return this.conversationConfigurationId !== undefined;
   }
 
   /**

--- a/packages/core/src/lib/config.ts
+++ b/packages/core/src/lib/config.ts
@@ -79,14 +79,12 @@ export class TACConfig {
    * Required environment variables:
    * - TWILIO_ACCOUNT_SID: Twilio Account SID
    * - TWILIO_AUTH_TOKEN: Twilio Auth Token for API authentication
-   * - TWILIO_PHONE_NUMBER: Phone number for voice and SMS channels
-   *
-   * Required for orchestrated mode (when TWILIO_CONVERSATION_CONFIGURATION_ID is set):
    * - TWILIO_API_KEY: Twilio API Key SID (starts with SK)
    * - TWILIO_API_SECRET: Twilio API Secret for API Key authentication
-   * - TWILIO_CONVERSATION_CONFIGURATION_ID: Conversation Orchestrator configuration ID
+   * - TWILIO_PHONE_NUMBER: Phone number for voice and SMS channels
    *
    * Optional environment variables:
+   * - TWILIO_CONVERSATION_CONFIGURATION_ID: Conversation Orchestrator configuration ID (enables orchestrated mode)
    * - VOICE_PUBLIC_DOMAIN: Public domain for voice webhooks
    * - TWILIO_REGION: Twilio region subdomain for API routing (e.g. transforms base URLs to `https://{product}.{region}.twilio.com`)
    * - TWILIO_STUDIO_HANDOFF_FLOW_SID: Studio Flow SID used by createStudioHandoffTool for human handoff

--- a/packages/core/src/lib/tac.ts
+++ b/packages/core/src/lib/tac.ts
@@ -110,7 +110,9 @@ export class TAC {
     const tac = new TAC(TAC.FACTORY_TOKEN, options);
 
     if (!tac.config.isOrchestratorEnabled()) {
-      tac.logger.info('Voice-only mode: conversationConfigurationId not set, skipping Conversation Orchestrator initialization');
+      tac.logger.info(
+        'Voice-only mode: conversationConfigurationId not set, skipping Conversation Orchestrator initialization'
+      );
       return tac;
     }
 
@@ -120,12 +122,10 @@ export class TAC {
         tac.logger.child({ component: 'conversation' })
       );
 
-      const configId = tac.config.conversationConfigurationId;
-      if (!configId) {
-        throw new Error('conversationConfigurationId is required when orchestrator is enabled');
-      }
-
-      const conversationConfig = await tac.conversationClient.getConfiguration(configId);
+      // Safe: we already returned early if !isOrchestratorEnabled(), so conversationConfigurationId is defined
+      const conversationConfig = await tac.conversationClient.getConfiguration(
+        tac.config.conversationConfigurationId!
+      );
 
       tac.memoryStoreId = conversationConfig.memoryStoreId;
       // TODO(conv-orch): Remove once the Actions API resolves the V1 Chat service SID

--- a/packages/core/src/lib/tac.ts
+++ b/packages/core/src/lib/tac.ts
@@ -58,13 +58,13 @@ export class TAC {
 
   private readonly config: TACConfig;
   public readonly logger: Logger;
-  private memoryClient!: MemoryClient;
-  private knowledgeClient!: KnowledgeClient;
-  private readonly conversationClient: ConversationClient;
+  private memoryClient: MemoryClient | null = null;
+  private knowledgeClient: KnowledgeClient | null = null;
+  private conversationClient: ConversationClient | null = null;
   private readonly channels: Map<ChannelType, BaseChannel>;
   private cintelProcessor?: OperatorResultProcessor;
 
-  private memoryStoreId!: string;
+  private memoryStoreId: string | undefined;
 
   /**
    * V1 Conversations service SID sourced from `conversationsV1Bridge.serviceId`
@@ -104,19 +104,28 @@ export class TAC {
     this.config = finalConfig;
     this.logger = finalLogger;
     this.channels = new Map();
-    this.conversationClient = new ConversationClient(
-      this.config,
-      this.logger.child({ component: 'conversation' })
-    );
   }
 
   public static async create(options: TACOptions = {}): Promise<TAC> {
     const tac = new TAC(TAC.FACTORY_TOKEN, options);
 
+    if (!tac.config.isOrchestratorEnabled()) {
+      tac.logger.info('Voice-only mode: conversationConfigurationId not set, skipping Conversation Orchestrator initialization');
+      return tac;
+    }
+
     try {
-      const conversationConfig = await tac.conversationClient.getConfiguration(
-        tac.config.conversationConfigurationId
+      tac.conversationClient = new ConversationClient(
+        tac.config,
+        tac.logger.child({ component: 'conversation' })
       );
+
+      const configId = tac.config.conversationConfigurationId;
+      if (!configId) {
+        throw new Error('conversationConfigurationId is required when orchestrator is enabled');
+      }
+
+      const conversationConfig = await tac.conversationClient.getConfiguration(configId);
 
       tac.memoryStoreId = conversationConfig.memoryStoreId;
       // TODO(conv-orch): Remove once the Actions API resolves the V1 Chat service SID
@@ -334,7 +343,7 @@ export class TAC {
 
       // Get memory if not already provided and profile ID exists
       let memory = data.userMemory;
-      if (!memory && data.profileId) {
+      if (!memory && data.profileId && this.memoryClient) {
         this.logger.debug(
           { profile_id: data.profileId, operation: 'memory_retrieval' },
           'Retrieving memory for profile'
@@ -437,6 +446,14 @@ export class TAC {
   }
 
   /**
+   * Whether Conversation Orchestrator is configured.
+   * Returns false in voice-only mode.
+   */
+  public isOrchestratorEnabled(): boolean {
+    return this.config.isOrchestratorEnabled();
+  }
+
+  /**
    * Get registered channel by type
    */
   public getChannel<T extends BaseChannel>(channelType: ChannelType): T | undefined {
@@ -451,30 +468,34 @@ export class TAC {
   }
 
   /**
-   * Get memory client for advanced memory operations
+   * Get memory client for advanced memory operations.
+   * Returns null in voice-only mode.
    */
-  public getMemoryClient(): MemoryClient {
+  public getMemoryClient(): MemoryClient | null {
     return this.memoryClient;
   }
 
   /**
    * Get the memory store ID resolved from the ConversationConfiguration at startup.
+   * Returns undefined in voice-only mode.
    */
-  public getMemoryStoreId(): string {
+  public getMemoryStoreId(): string | undefined {
     return this.memoryStoreId;
   }
 
   /**
-   * Get knowledge client for knowledge base operations
+   * Get knowledge client for knowledge base operations.
+   * Returns null in voice-only mode.
    */
-  public getKnowledgeClient(): KnowledgeClient {
+  public getKnowledgeClient(): KnowledgeClient | null {
     return this.knowledgeClient;
   }
 
   /**
-   * Get conversation client for advanced conversation operations
+   * Get conversation client for advanced conversation operations.
+   * Returns null in voice-only mode.
    */
-  public getConversationClient(): ConversationClient {
+  public getConversationClient(): ConversationClient | null {
     return this.conversationClient;
   }
 
@@ -523,6 +544,10 @@ export class TAC {
     session: ConversationSession,
     query?: string
   ): Promise<TACMemoryResponse> {
+    if (!this.isOrchestratorEnabled()) {
+      return new TACMemoryResponse([]);
+    }
+
     try {
       // If profileId is missing, try to lookup profile using address
       if (!session.profileId) {
@@ -555,6 +580,10 @@ export class TAC {
           'profileId not found, attempting to lookup profile'
         );
 
+        if (!this.memoryClient) {
+          throw new Error('Memory client is not available');
+        }
+
         // Lookup profile using appropriate identity type
         const lookupResponse = await this.memoryClient.lookupProfile(
           identityType,
@@ -578,6 +607,10 @@ export class TAC {
         throw new Error('Profile ID is required but was not resolved');
       }
 
+      if (!this.memoryClient) {
+        throw new Error('Memory client is not available');
+      }
+
       const memoryResponse = await this.memoryClient.retrieveMemories(session.profileId, {
         conversationId: session.conversationId,
         query,
@@ -594,6 +627,9 @@ export class TAC {
       );
 
       try {
+        if (!this.conversationClient) {
+          throw new Error('Conversation client is not available');
+        }
         const communications = await this.conversationClient.listCommunications(
           session.conversationId
         );
@@ -615,6 +651,11 @@ export class TAC {
   public async fetchProfile(profileId: string): Promise<ProfileResponse | undefined> {
     if (!profileId) {
       this.logger.warn('profile_id is required for profile fetching but was not provided');
+      return undefined;
+    }
+
+    if (!this.memoryClient) {
+      this.logger.warn('Memory client is not available (voice-only mode)');
       return undefined;
     }
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -23,52 +23,42 @@ export type TwilioMemoryConfig = z.infer<typeof TwilioMemoryConfigSchema>;
 /**
  * TAC configuration schema
  */
-export const TACConfigSchema = z
-  .object({
-    accountSid: z.string().min(1, 'Twilio Account SID is required'),
-    authToken: z.string().min(1, 'Twilio Auth Token is required'),
-    apiKey: z.string().min(1, 'Twilio API Key is required').optional(),
-    apiSecret: z.string().min(1, 'Twilio API Secret is required').optional(),
-    phoneNumber: z.string().min(1, 'Twilio Phone Number is required'),
-    memoryConfig: TwilioMemoryConfigSchema.default({}),
-    conversationConfigurationId: z
-      .string()
-      .regex(/^conv_configuration_[0-9a-z]{26}$/, 'Invalid Conversation Configuration ID format')
-      .optional(),
-    voicePublicDomain: z.string().url().optional(),
-    cintelConfigurationId: z.string().optional(),
-    cintelObservationOperatorSid: z.string().optional(),
-    cintelSummaryOperatorSid: z.string().optional(),
-    region: z
-      .string()
-      .max(63, 'Invalid Twilio region format (must be a valid DNS label)')
-      .regex(
-        /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/,
-        'Invalid Twilio region format (must be a valid DNS label)'
-      )
-      .optional(),
-    /**
-     * Twilio Studio Flow SID (FWxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx) for handoff.
-     * TAC derives both the digital-handoff Studio Executions URL and the voice
-     * `<Connect action>` webhook URL from this SID.
-     */
-    studioHandoffFlowSid: z
-      .string()
-      .regex(
-        /^FW[0-9a-f]{32}$/,
-        'Invalid Studio Flow SID format (expected FW followed by 32 hex chars)'
-      )
-      .optional(),
-  })
-  .refine(
-    data =>
-      !data.conversationConfigurationId || (data.apiKey !== undefined && data.apiSecret !== undefined),
-    {
-      message:
-        'apiKey and apiSecret are required when conversationConfigurationId is set',
-      path: ['apiKey'],
-    }
-  );
+export const TACConfigSchema = z.object({
+  accountSid: z.string().min(1, 'Twilio Account SID is required'),
+  authToken: z.string().min(1, 'Twilio Auth Token is required'),
+  apiKey: z.string().min(1, 'Twilio API Key is required'),
+  apiSecret: z.string().min(1, 'Twilio API Secret is required'),
+  phoneNumber: z.string().min(1, 'Twilio Phone Number is required'),
+  memoryConfig: TwilioMemoryConfigSchema.default({}),
+  conversationConfigurationId: z
+    .string()
+    .regex(/^conv_configuration_[0-9a-z]{26}$/, 'Invalid Conversation Configuration ID format')
+    .optional(),
+  voicePublicDomain: z.string().url().optional(),
+  cintelConfigurationId: z.string().optional(),
+  cintelObservationOperatorSid: z.string().optional(),
+  cintelSummaryOperatorSid: z.string().optional(),
+  region: z
+    .string()
+    .max(63, 'Invalid Twilio region format (must be a valid DNS label)')
+    .regex(
+      /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/,
+      'Invalid Twilio region format (must be a valid DNS label)'
+    )
+    .optional(),
+  /**
+   * Twilio Studio Flow SID (FWxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx) for handoff.
+   * TAC derives both the digital-handoff Studio Executions URL and the voice
+   * `<Connect action>` webhook URL from this SID.
+   */
+  studioHandoffFlowSid: z
+    .string()
+    .regex(
+      /^FW[0-9a-f]{32}$/,
+      'Invalid Studio Flow SID format (expected FW followed by 32 hex chars)'
+    )
+    .optional(),
+});
 
 export type TACConfigData = z.infer<typeof TACConfigSchema>;
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -23,41 +23,52 @@ export type TwilioMemoryConfig = z.infer<typeof TwilioMemoryConfigSchema>;
 /**
  * TAC configuration schema
  */
-export const TACConfigSchema = z.object({
-  accountSid: z.string().min(1, 'Twilio Account SID is required'),
-  authToken: z.string().min(1, 'Twilio Auth Token is required'),
-  apiKey: z.string().min(1, 'Twilio API Key is required'),
-  apiSecret: z.string().min(1, 'Twilio API Secret is required'),
-  phoneNumber: z.string().min(1, 'Twilio Phone Number is required'),
-  memoryConfig: TwilioMemoryConfigSchema.default({}),
-  conversationConfigurationId: z
-    .string()
-    .regex(/^conv_configuration_[0-9a-z]{26}$/, 'Invalid Conversation Configuration ID format'),
-  voicePublicDomain: z.string().url().optional(),
-  cintelConfigurationId: z.string().optional(),
-  cintelObservationOperatorSid: z.string().optional(),
-  cintelSummaryOperatorSid: z.string().optional(),
-  region: z
-    .string()
-    .max(63, 'Invalid Twilio region format (must be a valid DNS label)')
-    .regex(
-      /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/,
-      'Invalid Twilio region format (must be a valid DNS label)'
-    )
-    .optional(),
-  /**
-   * Twilio Studio Flow SID (FWxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx) for handoff.
-   * TAC derives both the digital-handoff Studio Executions URL and the voice
-   * `<Connect action>` webhook URL from this SID.
-   */
-  studioHandoffFlowSid: z
-    .string()
-    .regex(
-      /^FW[0-9a-f]{32}$/,
-      'Invalid Studio Flow SID format (expected FW followed by 32 hex chars)'
-    )
-    .optional(),
-});
+export const TACConfigSchema = z
+  .object({
+    accountSid: z.string().min(1, 'Twilio Account SID is required'),
+    authToken: z.string().min(1, 'Twilio Auth Token is required'),
+    apiKey: z.string().min(1, 'Twilio API Key is required').optional(),
+    apiSecret: z.string().min(1, 'Twilio API Secret is required').optional(),
+    phoneNumber: z.string().min(1, 'Twilio Phone Number is required'),
+    memoryConfig: TwilioMemoryConfigSchema.default({}),
+    conversationConfigurationId: z
+      .string()
+      .regex(/^conv_configuration_[0-9a-z]{26}$/, 'Invalid Conversation Configuration ID format')
+      .optional(),
+    voicePublicDomain: z.string().url().optional(),
+    cintelConfigurationId: z.string().optional(),
+    cintelObservationOperatorSid: z.string().optional(),
+    cintelSummaryOperatorSid: z.string().optional(),
+    region: z
+      .string()
+      .max(63, 'Invalid Twilio region format (must be a valid DNS label)')
+      .regex(
+        /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/,
+        'Invalid Twilio region format (must be a valid DNS label)'
+      )
+      .optional(),
+    /**
+     * Twilio Studio Flow SID (FWxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx) for handoff.
+     * TAC derives both the digital-handoff Studio Executions URL and the voice
+     * `<Connect action>` webhook URL from this SID.
+     */
+    studioHandoffFlowSid: z
+      .string()
+      .regex(
+        /^FW[0-9a-f]{32}$/,
+        'Invalid Studio Flow SID format (expected FW followed by 32 hex chars)'
+      )
+      .optional(),
+  })
+  .refine(
+    data =>
+      !data.conversationConfigurationId || (data.apiKey !== undefined && data.apiSecret !== undefined),
+    {
+      message:
+        'apiKey and apiSecret are required when conversationConfigurationId is set',
+      path: ['apiKey'],
+    }
+  );
 
 export type TACConfigData = z.infer<typeof TACConfigSchema>;
 

--- a/packages/tools/src/built-in/handoff.ts
+++ b/packages/tools/src/built-in/handoff.ts
@@ -107,6 +107,13 @@ const DEFAULT_HANDOFF_TOOL_DESCRIPTION =
  * The tool also sets the conversation to INACTIVE and clears status callbacks
  * to prevent further webhook events from being routed to TAC.
  *
+ * **Not available in voice-only mode.** This tool requires Conversation
+ * Orchestrator for conversation state management and Conversation Memory for
+ * the handoff payload. In voice-only mode, implement your own handoff by
+ * setting `session.pendingHandoffData` directly — the voice channel will
+ * send the WS `end` message with your payload, and your `<Connect action>`
+ * URL handler can route the call accordingly.
+ *
  * @throws Error if `tac.getConfig().studioHandoffFlowSid` is unset. The
  *   factory is Studio-specific; a missing SID is misconfiguration, not a
  *   soft fallback.

--- a/packages/tools/src/built-in/handoff.ts
+++ b/packages/tools/src/built-in/handoff.ts
@@ -114,9 +114,9 @@ const DEFAULT_HANDOFF_TOOL_DESCRIPTION =
  * send the WS `end` message with your payload, and your `<Connect action>`
  * URL handler can route the call accordingly.
  *
- * @throws Error if `tac.getConfig().studioHandoffFlowSid` is unset. The
- *   factory is Studio-specific; a missing SID is misconfiguration, not a
- *   soft fallback.
+ * @throws Error if `tac.getConfig().studioHandoffFlowSid` is unset, if
+ *   Conversation Orchestrator is not configured (voice-only mode), or if
+ *   the memory store ID was not resolved at startup.
  */
 export function createStudioHandoffTool(
   tac: TAC,
@@ -135,6 +135,21 @@ export function createStudioHandoffTool(
     );
   }
   const flowSid = config.studioHandoffFlowSid;
+
+  const coClient = tac.getConversationClient();
+  if (!coClient) {
+    throw new Error(
+      'createStudioHandoffTool requires Conversation Orchestrator ' +
+        '(not available in voice-only mode)'
+    );
+  }
+  const memoryStoreId = tac.getMemoryStoreId();
+  if (!memoryStoreId) {
+    throw new Error(
+      'createStudioHandoffTool requires a memory store ID ' +
+        '(resolved from conversationConfigurationId at startup)'
+    );
+  }
 
   const staticAttributes = options.attributes ?? {};
   const toolName = options.name ?? DEFAULT_HANDOFF_TOOL_NAME;
@@ -156,18 +171,6 @@ export function createStudioHandoffTool(
     },
     async (params: HandoffParams): Promise<HandoffResult> => {
       const attributes = { ...staticAttributes, reason: params.reason };
-
-      const coClient = tac.getConversationClient();
-      if (!coClient) {
-        throw new Error(
-          'Handoff requires Conversation Orchestrator (not available in voice-only mode)'
-        );
-      }
-      const memoryStoreId = tac.getMemoryStoreId();
-      if (!memoryStoreId) {
-        throw new Error('Memory store ID is not available (required for handoff)');
-      }
-
       const payload = buildHandoffPayload(session, memoryStoreId, attributes);
 
       // 1. Set conversation to INACTIVE to trigger the CO-generated

--- a/packages/tools/src/built-in/handoff.ts
+++ b/packages/tools/src/built-in/handoff.ts
@@ -151,7 +151,13 @@ export function createStudioHandoffTool(
       const attributes = { ...staticAttributes, reason: params.reason };
 
       const coClient = tac.getConversationClient();
+      if (!coClient) {
+        throw new Error('Handoff requires Conversation Orchestrator (not available in voice-only mode)');
+      }
       const memoryStoreId = tac.getMemoryStoreId();
+      if (!memoryStoreId) {
+        throw new Error('Memory store ID is not available (required for handoff)');
+      }
 
       const payload = buildHandoffPayload(session, memoryStoreId, attributes);
 
@@ -197,6 +203,9 @@ export function createStudioHandoffTool(
         // handoff_failed so the LLM can tell the user instead of claiming
         // success.
         try {
+          if (!config.apiKey || !config.apiSecret) {
+            throw new Error('apiKey and apiSecret are required for Studio handoff');
+          }
           await postStudioHandoff(payload, session, {
             handoffUrl: studioExecutionsUrl(flowSid),
             fromAddress: config.phoneNumber,

--- a/packages/tools/src/built-in/handoff.ts
+++ b/packages/tools/src/built-in/handoff.ts
@@ -203,9 +203,6 @@ export function createStudioHandoffTool(
         // handoff_failed so the LLM can tell the user instead of claiming
         // success.
         try {
-          if (!config.apiKey || !config.apiSecret) {
-            throw new Error('apiKey and apiSecret are required for Studio handoff');
-          }
           await postStudioHandoff(payload, session, {
             handoffUrl: studioExecutionsUrl(flowSid),
             fromAddress: config.phoneNumber,

--- a/packages/tools/src/built-in/handoff.ts
+++ b/packages/tools/src/built-in/handoff.ts
@@ -152,7 +152,9 @@ export function createStudioHandoffTool(
 
       const coClient = tac.getConversationClient();
       if (!coClient) {
-        throw new Error('Handoff requires Conversation Orchestrator (not available in voice-only mode)');
+        throw new Error(
+          'Handoff requires Conversation Orchestrator (not available in voice-only mode)'
+        );
       }
       const memoryStoreId = tac.getMemoryStoreId();
       if (!memoryStoreId) {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -209,15 +209,6 @@ describe('TACConfig', () => {
       expect(config.isOrchestratorEnabled()).toBe(false);
     });
 
-    it('should throw when TWILIO_API_KEY is missing even with conversationConfigurationId', () => {
-      setRequiredEnvVars();
-      delete process.env.TWILIO_API_KEY;
-
-      expect(() => {
-        TACConfig.fromEnv();
-      }).toThrow('Missing required environment variable: TWILIO_API_KEY');
-    });
-
     it('should throw error when no environment variables are set', () => {
       Object.keys(originalEnv).forEach(key => {
         delete process.env[key];

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -173,24 +173,22 @@ describe('TACConfig', () => {
       }).toThrow('Missing required environment variable: TWILIO_AUTH_TOKEN');
     });
 
-    it('should succeed without TWILIO_API_KEY in relay-only mode', () => {
+    it('should throw error when TWILIO_API_KEY is missing', () => {
       setRequiredEnvVars();
       delete process.env.TWILIO_API_KEY;
-      delete process.env.TWILIO_CONVERSATION_CONFIGURATION_ID;
 
-      const config = TACConfig.fromEnv();
-      expect(config.apiKey).toBeUndefined();
-      expect(config.isOrchestratorEnabled()).toBe(false);
+      expect(() => {
+        TACConfig.fromEnv();
+      }).toThrow('Missing required environment variable: TWILIO_API_KEY');
     });
 
-    it('should succeed without TWILIO_API_SECRET in relay-only mode', () => {
+    it('should throw error when TWILIO_API_SECRET is missing', () => {
       setRequiredEnvVars();
       delete process.env.TWILIO_API_SECRET;
-      delete process.env.TWILIO_CONVERSATION_CONFIGURATION_ID;
 
-      const config = TACConfig.fromEnv();
-      expect(config.apiSecret).toBeUndefined();
-      expect(config.isOrchestratorEnabled()).toBe(false);
+      expect(() => {
+        TACConfig.fromEnv();
+      }).toThrow('Missing required environment variable: TWILIO_API_SECRET');
     });
 
     it('should throw error when TWILIO_PHONE_NUMBER is missing', () => {
@@ -211,13 +209,13 @@ describe('TACConfig', () => {
       expect(config.isOrchestratorEnabled()).toBe(false);
     });
 
-    it('should throw when conversationConfigurationId is set without apiKey/apiSecret', () => {
+    it('should throw when TWILIO_API_KEY is missing even with conversationConfigurationId', () => {
       setRequiredEnvVars();
       delete process.env.TWILIO_API_KEY;
 
       expect(() => {
         TACConfig.fromEnv();
-      }).toThrow('apiKey and apiSecret are required when conversationConfigurationId is set');
+      }).toThrow('Missing required environment variable: TWILIO_API_KEY');
     });
 
     it('should throw error when no environment variables are set', () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -173,22 +173,24 @@ describe('TACConfig', () => {
       }).toThrow('Missing required environment variable: TWILIO_AUTH_TOKEN');
     });
 
-    it('should throw error when TWILIO_API_KEY is missing', () => {
+    it('should succeed without TWILIO_API_KEY in relay-only mode', () => {
       setRequiredEnvVars();
       delete process.env.TWILIO_API_KEY;
+      delete process.env.TWILIO_CONVERSATION_CONFIGURATION_ID;
 
-      expect(() => {
-        TACConfig.fromEnv();
-      }).toThrow('Missing required environment variable: TWILIO_API_KEY');
+      const config = TACConfig.fromEnv();
+      expect(config.apiKey).toBeUndefined();
+      expect(config.isOrchestratorEnabled()).toBe(false);
     });
 
-    it('should throw error when TWILIO_API_SECRET is missing', () => {
+    it('should succeed without TWILIO_API_SECRET in relay-only mode', () => {
       setRequiredEnvVars();
       delete process.env.TWILIO_API_SECRET;
+      delete process.env.TWILIO_CONVERSATION_CONFIGURATION_ID;
 
-      expect(() => {
-        TACConfig.fromEnv();
-      }).toThrow('Missing required environment variable: TWILIO_API_SECRET');
+      const config = TACConfig.fromEnv();
+      expect(config.apiSecret).toBeUndefined();
+      expect(config.isOrchestratorEnabled()).toBe(false);
     });
 
     it('should throw error when TWILIO_PHONE_NUMBER is missing', () => {
@@ -200,13 +202,22 @@ describe('TACConfig', () => {
       }).toThrow('Missing required environment variable: TWILIO_PHONE_NUMBER');
     });
 
-    it('should throw error when TWILIO_CONVERSATION_CONFIGURATION_ID is missing', () => {
+    it('should succeed without TWILIO_CONVERSATION_CONFIGURATION_ID (relay-only mode)', () => {
       setRequiredEnvVars();
       delete process.env.TWILIO_CONVERSATION_CONFIGURATION_ID;
 
+      const config = TACConfig.fromEnv();
+      expect(config.conversationConfigurationId).toBeUndefined();
+      expect(config.isOrchestratorEnabled()).toBe(false);
+    });
+
+    it('should throw when conversationConfigurationId is set without apiKey/apiSecret', () => {
+      setRequiredEnvVars();
+      delete process.env.TWILIO_API_KEY;
+
       expect(() => {
         TACConfig.fromEnv();
-      }).toThrow('Missing required environment variable: TWILIO_CONVERSATION_CONFIGURATION_ID');
+      }).toThrow('apiKey and apiSecret are required when conversationConfigurationId is set');
     });
 
     it('should throw error when no environment variables are set', () => {

--- a/tests/handoff.test.ts
+++ b/tests/handoff.test.ts
@@ -3,6 +3,8 @@ import axios from 'axios';
 import {
   ConversationSession,
   HandoffPayload,
+  TAC,
+  TACConfig,
   TACConfigData,
   studioExecutionsUrl,
   studioVoiceHandoffUrl,
@@ -106,7 +108,7 @@ describe('createStudioHandoffTool factory', () => {
   });
 
   it('throws in voice-only mode (no Conversation Orchestrator)', async () => {
-    const config = new (await import('@twilio/tac-core')).TACConfig({
+    const config = new TACConfig({
       accountSid: ACCOUNT_SID,
       authToken: 'test_token_123',
       apiKey: 'SK123',
@@ -114,7 +116,7 @@ describe('createStudioHandoffTool factory', () => {
       phoneNumber: '+15551234567',
       studioHandoffFlowSid: FLOW_SID,
     });
-    const tac = await (await import('@twilio/tac-core')).TAC.create({ config });
+    const tac = await TAC.create({ config });
 
     expect(() => createStudioHandoffTool(tac, makeSession())).toThrowError(
       /Conversation Orchestrator/

--- a/tests/handoff.test.ts
+++ b/tests/handoff.test.ts
@@ -104,6 +104,22 @@ describe('createStudioHandoffTool factory', () => {
       /studioHandoffFlowSid/
     );
   });
+
+  it('throws in voice-only mode (no Conversation Orchestrator)', async () => {
+    const config = new (await import('@twilio/tac-core')).TACConfig({
+      accountSid: ACCOUNT_SID,
+      authToken: 'test_token_123',
+      apiKey: 'SK123',
+      apiSecret: 'test_api_secret',
+      phoneNumber: '+15551234567',
+      studioHandoffFlowSid: FLOW_SID,
+    });
+    const tac = await (await import('@twilio/tac-core')).TAC.create({ config });
+
+    expect(() => createStudioHandoffTool(tac, makeSession())).toThrowError(
+      /Conversation Orchestrator/
+    );
+  });
 });
 
 describe('handoff tool execution — voice channel', () => {

--- a/tests/relay-only.test.ts
+++ b/tests/relay-only.test.ts
@@ -11,8 +11,6 @@ const getRelayOnlyConfigData = () => ({
 
 const getOrchestratedConfigData = () => ({
   ...getRelayOnlyConfigData(),
-  apiKey: 'SKtest123456789',
-  apiSecret: 'test_api_token_123',
   conversationConfigurationId: 'conv_configuration_01kbjqhn79f0fvwfsxqzd5nqhd',
 });
 

--- a/tests/relay-only.test.ts
+++ b/tests/relay-only.test.ts
@@ -4,6 +4,8 @@ import { TAC, TACConfig, VoiceChannel, SMSChannel, ChatChannel } from '@twilio/t
 const getRelayOnlyConfigData = () => ({
   accountSid: 'ACtest123456789',
   authToken: 'test_token_123',
+  apiKey: 'SKtest123456789',
+  apiSecret: 'test_api_secret_123',
   phoneNumber: '+15551234567',
 });
 
@@ -19,8 +21,8 @@ describe('Relay-Only Mode', () => {
     it('should create config without conversationConfigurationId', () => {
       const config = new TACConfig(getRelayOnlyConfigData());
       expect(config.conversationConfigurationId).toBeUndefined();
-      expect(config.apiKey).toBeUndefined();
-      expect(config.apiSecret).toBeUndefined();
+      expect(config.apiKey).toBe('SKtest123456789');
+      expect(config.apiSecret).toBe('test_api_secret_123');
     });
 
     it('isOrchestratorEnabled() returns false in relay-only mode', () => {
@@ -33,23 +35,18 @@ describe('Relay-Only Mode', () => {
       expect(config.isOrchestratorEnabled()).toBe(true);
     });
 
-    it('should throw when conversationConfigurationId is set without apiKey', () => {
+    it('should throw when apiKey is missing', () => {
+      const { apiKey: _, ...withoutApiKey } = getRelayOnlyConfigData();
       expect(() => {
-        new TACConfig({
-          ...getRelayOnlyConfigData(),
-          conversationConfigurationId: 'conv_configuration_01kbjqhn79f0fvwfsxqzd5nqhd',
-        });
-      }).toThrow('apiKey and apiSecret are required when conversationConfigurationId is set');
+        new TACConfig(withoutApiKey as any);
+      }).toThrow();
     });
 
-    it('should throw when conversationConfigurationId is set without apiSecret', () => {
+    it('should throw when apiSecret is missing', () => {
+      const { apiSecret: _, ...withoutApiSecret } = getRelayOnlyConfigData();
       expect(() => {
-        new TACConfig({
-          ...getRelayOnlyConfigData(),
-          apiKey: 'SKtest123456789',
-          conversationConfigurationId: 'conv_configuration_01kbjqhn79f0fvwfsxqzd5nqhd',
-        });
-      }).toThrow('apiKey and apiSecret are required when conversationConfigurationId is set');
+        new TACConfig(withoutApiSecret as any);
+      }).toThrow();
     });
   });
 
@@ -240,6 +237,32 @@ describe('Relay-Only Mode', () => {
       });
 
       expect(voiceChannel.getConversationSession('CA_cb_relay')).toBeUndefined();
+    });
+
+    it('handleConversationRelayCallback rejects mismatched AccountSid', async () => {
+      const connected = new Promise<void>(resolve => {
+        voiceChannel.on('webSocketConnected', () => resolve());
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockWs = createMockWebSocket() as any;
+      voiceChannel.handleWebSocketConnection(mockWs);
+
+      mockWs._emit('message', Buffer.from(setupMessage('CA_bad_acct')));
+      mockWs._emit('message', Buffer.from(promptMessage));
+      await connected;
+
+      const result = await voiceChannel.handleConversationRelayCallback({
+        CallSid: 'CA_bad_acct',
+        CallStatus: 'completed',
+        AccountSid: 'AC_wrong_account',
+        From: '+15551112222',
+        To: '+15553334444',
+        Direction: 'inbound',
+      });
+
+      expect(result.status).toBe(403);
+      expect(voiceChannel.getConversationSession('CA_bad_acct')).toBeDefined();
     });
 
     it('handleConversationRelayCallback ignores non-completed status', async () => {

--- a/tests/relay-only.test.ts
+++ b/tests/relay-only.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TAC, TACConfig, VoiceChannel, SMSChannel, ChatChannel } from '@twilio/tac-core';
+
+const getRelayOnlyConfigData = () => ({
+  accountSid: 'ACtest123456789',
+  authToken: 'test_token_123',
+  phoneNumber: '+15551234567',
+});
+
+const getOrchestratedConfigData = () => ({
+  ...getRelayOnlyConfigData(),
+  apiKey: 'SKtest123456789',
+  apiSecret: 'test_api_token_123',
+  conversationConfigurationId: 'conv_configuration_01kbjqhn79f0fvwfsxqzd5nqhd',
+});
+
+describe('Relay-Only Mode', () => {
+  describe('TACConfig', () => {
+    it('should create config without conversationConfigurationId', () => {
+      const config = new TACConfig(getRelayOnlyConfigData());
+      expect(config.conversationConfigurationId).toBeUndefined();
+      expect(config.apiKey).toBeUndefined();
+      expect(config.apiSecret).toBeUndefined();
+    });
+
+    it('isOrchestratorEnabled() returns false in relay-only mode', () => {
+      const config = new TACConfig(getRelayOnlyConfigData());
+      expect(config.isOrchestratorEnabled()).toBe(false);
+    });
+
+    it('isOrchestratorEnabled() returns true when conversationConfigurationId is set', () => {
+      const config = new TACConfig(getOrchestratedConfigData());
+      expect(config.isOrchestratorEnabled()).toBe(true);
+    });
+
+    it('should throw when conversationConfigurationId is set without apiKey', () => {
+      expect(() => {
+        new TACConfig({
+          ...getRelayOnlyConfigData(),
+          conversationConfigurationId: 'conv_configuration_01kbjqhn79f0fvwfsxqzd5nqhd',
+        });
+      }).toThrow('apiKey and apiSecret are required when conversationConfigurationId is set');
+    });
+
+    it('should throw when conversationConfigurationId is set without apiSecret', () => {
+      expect(() => {
+        new TACConfig({
+          ...getRelayOnlyConfigData(),
+          apiKey: 'SKtest123456789',
+          conversationConfigurationId: 'conv_configuration_01kbjqhn79f0fvwfsxqzd5nqhd',
+        });
+      }).toThrow('apiKey and apiSecret are required when conversationConfigurationId is set');
+    });
+  });
+
+  describe('TAC initialization', () => {
+    it('should initialize without conversationConfigurationId', async () => {
+      const config = new TACConfig(getRelayOnlyConfigData());
+      const tac = await TAC.create({ config });
+
+      expect(tac.isOrchestratorEnabled()).toBe(false);
+    });
+
+    it('getConversationClient() returns null in relay-only mode', async () => {
+      const config = new TACConfig(getRelayOnlyConfigData());
+      const tac = await TAC.create({ config });
+
+      expect(tac.getConversationClient()).toBeNull();
+    });
+
+    it('getMemoryClient() returns null in relay-only mode', async () => {
+      const config = new TACConfig(getRelayOnlyConfigData());
+      const tac = await TAC.create({ config });
+
+      expect(tac.getMemoryClient()).toBeNull();
+    });
+
+    it('getKnowledgeClient() returns null in relay-only mode', async () => {
+      const config = new TACConfig(getRelayOnlyConfigData());
+      const tac = await TAC.create({ config });
+
+      expect(tac.getKnowledgeClient()).toBeNull();
+    });
+
+    it('getMemoryStoreId() returns undefined in relay-only mode', async () => {
+      const config = new TACConfig(getRelayOnlyConfigData());
+      const tac = await TAC.create({ config });
+
+      expect(tac.getMemoryStoreId()).toBeUndefined();
+    });
+
+    it('retrieveMemory() returns empty response in relay-only mode', async () => {
+      const config = new TACConfig(getRelayOnlyConfigData());
+      const tac = await TAC.create({ config });
+
+      const memory = await tac.retrieveMemory({
+        conversationId: 'CA123',
+        channel: 'voice',
+        startedAt: new Date(),
+        metadata: {},
+      });
+
+      expect(memory).toBeDefined();
+      expect(memory.hasMemoryFeatures).toBe(false);
+    });
+  });
+
+  describe('Channel registration', () => {
+    it('VoiceChannel can be constructed in relay-only mode', async () => {
+      const config = new TACConfig(getRelayOnlyConfigData());
+      const tac = await TAC.create({ config });
+
+      const voiceChannel = new VoiceChannel(tac);
+      expect(voiceChannel.channelType).toBe('voice');
+    });
+
+    it('SMSChannel throws in voice-only mode', async () => {
+      const config = new TACConfig(getRelayOnlyConfigData());
+      const tac = await TAC.create({ config });
+
+      expect(() => new SMSChannel(tac)).toThrow(
+        'Messaging channels require conversationConfigurationId'
+      );
+    });
+
+    it('ChatChannel throws in voice-only mode', async () => {
+      const config = new TACConfig(getRelayOnlyConfigData());
+      const tac = await TAC.create({ config });
+
+      expect(() => new ChatChannel(tac)).toThrow(
+        'Messaging channels require conversationConfigurationId'
+      );
+    });
+  });
+
+  describe('Voice channel relay-only behavior', () => {
+    let tac: TAC;
+    let voiceChannel: VoiceChannel;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const createMockWebSocket = () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handlers: Record<string, ((...args: any[]) => void)[]> = {};
+      return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+          if (!handlers[event]) handlers[event] = [];
+          handlers[event].push(handler);
+        }),
+        send: vi.fn(),
+        close: vi.fn(),
+        readyState: 1,
+        _handlers: handlers,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        _emit(event: string, ...args: any[]) {
+          for (const h of handlers[event] || []) {
+            h(...args);
+          }
+        },
+      };
+    };
+
+    const setupMessage = (callSid: string) =>
+      JSON.stringify({
+        type: 'setup',
+        sessionId: `sess_${callSid}`,
+        callSid,
+        from: '+15551112222',
+        to: '+15553334444',
+        direction: 'inbound',
+        callType: 'call',
+        callStatus: 'ringing',
+        accountSid: 'ACtest123456789',
+      });
+
+    const promptMessage = JSON.stringify({ type: 'prompt', voicePrompt: 'Hello' });
+
+    beforeEach(async () => {
+      const config = new TACConfig(getRelayOnlyConfigData());
+      tac = await TAC.create({ config });
+      voiceChannel = new VoiceChannel(tac);
+      tac.registerChannel(voiceChannel);
+    });
+
+    it('uses callSid as conversationId on first prompt', async () => {
+      const connected = new Promise<void>(resolve => {
+        voiceChannel.on('webSocketConnected', () => resolve());
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockWs = createMockWebSocket() as any;
+      voiceChannel.handleWebSocketConnection(mockWs);
+
+      mockWs._emit('message', Buffer.from(setupMessage('CA_relay_test_123')));
+      mockWs._emit('message', Buffer.from(promptMessage));
+
+      await connected;
+
+      const session = voiceChannel.getConversationSession('CA_relay_test_123');
+      expect(session).toBeDefined();
+      expect(session?.conversationId).toBe('CA_relay_test_123');
+      expect(session?.authorInfo?.address).toBe('+15551112222');
+    });
+
+    it('TwiML omits conversationConfiguration in relay-only mode', () => {
+      const twiml = voiceChannel.handleIncomingCall({
+        conversationRelayConfig: {
+          url: 'wss://example.com/ws',
+          welcomeGreeting: 'Hello!',
+        },
+      });
+
+      expect(twiml).not.toContain('conversationConfiguration');
+      expect(twiml).toContain('wss://example.com/ws');
+      expect(twiml).toContain('Hello!');
+    });
+
+    it('handleConversationRelayCallback ends session on completed status', async () => {
+      const connected = new Promise<void>(resolve => {
+        voiceChannel.on('webSocketConnected', () => resolve());
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockWs = createMockWebSocket() as any;
+      voiceChannel.handleWebSocketConnection(mockWs);
+
+      mockWs._emit('message', Buffer.from(setupMessage('CA_cb_relay')));
+      mockWs._emit('message', Buffer.from(promptMessage));
+      await connected;
+
+      expect(voiceChannel.getConversationSession('CA_cb_relay')).toBeDefined();
+
+      await voiceChannel.handleConversationRelayCallback({
+        CallSid: 'CA_cb_relay',
+        CallStatus: 'completed',
+        AccountSid: 'ACtest123456789',
+        From: '+15551112222',
+        To: '+15553334444',
+        Direction: 'inbound',
+      });
+
+      expect(voiceChannel.getConversationSession('CA_cb_relay')).toBeUndefined();
+    });
+
+    it('handleConversationRelayCallback ignores non-completed status', async () => {
+      const connected = new Promise<void>(resolve => {
+        voiceChannel.on('webSocketConnected', () => resolve());
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockWs = createMockWebSocket() as any;
+      voiceChannel.handleWebSocketConnection(mockWs);
+
+      mockWs._emit('message', Buffer.from(setupMessage('CA_inprog')));
+      mockWs._emit('message', Buffer.from(promptMessage));
+      await connected;
+
+      await voiceChannel.handleConversationRelayCallback({
+        CallSid: 'CA_inprog',
+        CallStatus: 'in-progress',
+        AccountSid: 'ACtest123456789',
+        From: '+15551112222',
+        To: '+15553334444',
+        Direction: 'inbound',
+      });
+
+      expect(voiceChannel.getConversationSession('CA_inprog')).toBeDefined();
+    });
+
+    it('onConversationEnded callback fires on relay callback cleanup', async () => {
+      const ended = new Promise<void>(resolve => {
+        tac.onConversationEnded(() => resolve());
+      });
+
+      const connected = new Promise<void>(resolve => {
+        voiceChannel.on('webSocketConnected', () => resolve());
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockWs = createMockWebSocket() as any;
+      voiceChannel.handleWebSocketConnection(mockWs);
+
+      mockWs._emit('message', Buffer.from(setupMessage('CA_ended')));
+      mockWs._emit('message', Buffer.from(promptMessage));
+      await connected;
+
+      await voiceChannel.handleConversationRelayCallback({
+        CallSid: 'CA_ended',
+        CallStatus: 'completed',
+        AccountSid: 'ACtest123456789',
+        From: '+15551112222',
+        To: '+15553334444',
+        Direction: 'inbound',
+      });
+
+      await ended;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds voice-only mode: TAC operates with just VoiceChannel + ConversationRelay when `conversationConfigurationId` is omitted
- Uses `callSid` as `conversationId` directly (no Conversation Orchestrator polling)
- `apiKey`/`apiSecret` remain required so upgrading to orchestrated mode only requires adding `conversationConfigurationId`
- ConversationRelay callback validates `AccountSid` before processing session cleanup
- Messaging channels (SMS/Chat) throw at construction if orchestrator is not configured
- `createStudioHandoffTool` validates all prerequisites at factory time (fail-fast)

## Type of Change

- [x] New feature
- [x] Breaking change

## Breaking Changes

- `getConversationClient()` now returns `ConversationClient | null` (was `ConversationClient`)
- `getMemoryClient()` now returns `MemoryClient | null` (was `MemoryClient`)
- `getKnowledgeClient()` now returns `KnowledgeClient | null` (was `KnowledgeClient`)
- `getMemoryStoreId()` now returns `string | undefined` (was `string`)
- `conversationConfigurationId` removed from `fromEnv()` required env vars (now optional)

These return nullable types in voice-only mode (when `conversationConfigurationId` is not set). Existing orchestrated-mode code needs null checks or non-null assertions on these getters.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [ ] Tested E2E

## SDK Parity

This is the **TypeScript SDK**. If this change affects shared functionality, ensure the [Python SDK](https://github.com/twilio/twilio-agent-connect-python) is updated as well.

- [ ] Change is TypeScript-specific (no Python update needed)
- [x] Python SDK PR created: https://github.com/twilio/twilio-agent-connect-python/pull/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)