### PR TITLE
Synced from Python: Reconcile participant types pre-LLM, handle v1-bridge UNKNOWN

### DIFF
--- a/packages/core/src/channels/chat.ts
+++ b/packages/core/src/channels/chat.ts
@@ -1,6 +1,7 @@
 import {
   ActionChannelSettings,
   ChannelType,
+  ConversationAddress,
   ConversationId,
   SendMessageActionRequest,
   InitiateConversationResult,
@@ -11,16 +12,13 @@ import type { TAC } from '../lib/tac';
 import { maskAddress } from '../util/log-redaction';
 
 /**
- * Options for initiating an outbound chat conversation
+ * Options for initiating an outbound chat conversation.
+ *
+ * The sender is always the channel's configured `agentAddress`. Multi-sender
+ * deployments should run one TAC instance per sender.
  */
 export const InitiateChatConversationOptionsSchema = z.object({
   to: z.string().min(1, 'Recipient identity is required'),
-  /**
-   * Custom sender address. Defaults to agentAddress.
-   * Own-message filtering considers outbound sender values, including
-   * agentAddress and session metadata such as fromAddress.
-   */
-  from: z.string().optional(),
   channelId: z.string().min(1, 'Chat Channel SID is required'),
   message: z.string().min(1, 'Initial message is required'),
   metadata: z.record(z.unknown()).optional(),
@@ -46,6 +44,11 @@ export interface ChatChannelConfig extends MessagingChannelConfig {
 export class ChatChannel extends MessagingChannel {
   private readonly agentAddress: string;
 
+  // Chat identifies the customer author-driven from the webhook's
+  // `author.participantId`; promoting some other channel-matching UNKNOWN
+  // CHAT participant could pick the wrong recipient.
+  protected override reconcileCustomerType: boolean = false;
+
   constructor(tac: TAC, config?: ChatChannelConfig) {
     super(tac, config);
     this.agentAddress = config?.agentAddress ?? 'ai-assistant';
@@ -59,8 +62,27 @@ export class ChatChannel extends MessagingChannel {
     return authorAddress === this.agentAddress;
   }
 
+  protected getAgentAddress(conversationId: ConversationId): ConversationAddress {
+    const session = this.getConversationSession(conversationId);
+    const channelId =
+      session && typeof session.metadata?.channelId === 'string'
+        ? session.metadata.channelId
+        : undefined;
+    return {
+      channel: 'CHAT',
+      address: this.agentAddress,
+      ...(channelId ? { channelId } : {}),
+    };
+  }
+
   /**
    * Send chat response using the Conversation Orchestrator Actions API (SEND_MESSAGE).
+   *
+   * Reads the agent and customer participant ids stashed on the session by
+   * inbound reconciliation or outbound initiation. Missing ids are a misuse —
+   * `sendResponse` is only expected to be called after an inbound webhook
+   * (COMMUNICATION_CREATED → reconcile) or after `initiateOutboundConversation`,
+   * both of which populate the session.
    */
   public async sendResponse(
     conversationId: ConversationId,
@@ -79,19 +101,21 @@ export class ChatChannel extends MessagingChannel {
     try {
       const session = this.getConversationSession(conversationId);
 
-      if (!session) {
-        throw new Error(`No active session found for conversation ${conversationId}`);
-      }
-
-      if (!session.authorInfo) {
+      if (!session || !session.authorInfo || !session.aiAgentInfo) {
         throw new Error(
-          `No author info found for conversation ${conversationId} - no inbound message received yet`
+          `Unable to send chat message: sendResponse called without a reconciled session ` +
+            `for conversation ${conversationId}. Wait for an inbound webhook or call ` +
+            `initiateOutboundConversation first.`
         );
       }
 
-      const recipientParticipantId = session.authorInfo.participantId;
-      if (!recipientParticipantId) {
-        throw new Error(`No recipient participant ID found for conversation ${conversationId}`);
+      const customerParticipantId = session.authorInfo.participantId;
+      const agentParticipantId = session.aiAgentInfo.participantId;
+      if (!customerParticipantId || !agentParticipantId) {
+        throw new Error(
+          `Unable to send chat message: session for conversation ${conversationId} is ` +
+            `missing participant ids.`
+        );
       }
 
       // channelId (Chat Channel SID) is required for CHAT delivery — the V1
@@ -109,27 +133,6 @@ export class ChatChannel extends MessagingChannel {
         );
       }
 
-      // Fetch current participants from Conversation Orchestrator
-      const participants = await this.conversationClient.listParticipants(conversationId);
-
-      // Use fromAddress from session metadata (set during outbound initiation),
-      // falling back to the default agent address for inbound conversations
-      const effectiveAgentAddress =
-        typeof session.metadata?.fromAddress === 'string'
-          ? session.metadata.fromAddress
-          : this.agentAddress;
-
-      const agentParticipant = await this.ensureAgentParticipant(conversationId, participants, {
-        channel: 'CHAT',
-        address: effectiveAgentAddress,
-        channelId: chatChannelSid,
-      });
-      if (!agentParticipant) {
-        throw new Error(
-          `Failed to resolve AI_AGENT participant for conversation ${conversationId}`
-        );
-      }
-
       // TODO(conv-orch): Drop `chatService` here once the Actions API resolves
       // the V1 Chat service SID server-side. Confirmed this should not be
       // required client-side; keep the workaround until the server-side fix
@@ -143,9 +146,8 @@ export class ChatChannel extends MessagingChannel {
       this.logger.debug(
         {
           conversation_id: conversationId,
-          recipient_participant_id: session.authorInfo.participantId,
-          agent_participant_id: agentParticipant.id,
-          agent_address: effectiveAgentAddress,
+          recipient_participant_id: customerParticipantId,
+          agent_participant_id: agentParticipantId,
           channel_id: chatChannelSid,
         },
         'Sending chat message via Actions API'
@@ -156,12 +158,12 @@ export class ChatChannel extends MessagingChannel {
         payload: {
           from: {
             channel: 'CHAT',
-            participantId: agentParticipant.id,
+            participantId: agentParticipantId,
           },
           to: [
             {
               channel: 'CHAT',
-              participantId: recipientParticipantId,
+              participantId: customerParticipantId,
             },
           ],
           content: { text: message },
@@ -191,6 +193,7 @@ export class ChatChannel extends MessagingChannel {
    *
    * Creates a conversation via Conversation Orchestrator, adds customer and
    * agent participants, then sends the initial message via the Actions API.
+   * The sender is always this channel's configured `agentAddress`.
    */
   public async initiateOutboundConversation(
     options: InitiateChatConversationOptions
@@ -207,7 +210,7 @@ export class ChatChannel extends MessagingChannel {
     return this.initiateOutboundMessagingConversation({
       channel: 'CHAT',
       to: validated.to,
-      from: validated.from ?? this.agentAddress,
+      from: this.agentAddress,
       message: validated.message,
       ...(validated.metadata ? { metadata: validated.metadata } : {}),
       channelId: validated.channelId,

--- a/packages/core/src/channels/messaging.ts
+++ b/packages/core/src/channels/messaging.ts
@@ -172,9 +172,6 @@ export abstract class MessagingChannel extends BaseChannel {
    *
    * 1. Default agent address (stateless, no API call)
    * 2. API fallback via listParticipants (cross-process / multi-worker)
-   *
-   * `HUMAN_AGENT` is deliberately NOT treated as TAC — a real human is a
-   * separate participant and their messages must reach the callback.
    */
   private async isOwnMessage(
     authorAddress: string,
@@ -464,17 +461,14 @@ export abstract class MessagingChannel extends BaseChannel {
       }
 
       // Reconcile participant types pre-LLM so v1-bridge's UNKNOWN gets
-      // promoted to CUSTOMER (with a Memora profile attached when possible)
-      // and to stash both participant ids on the session for sendResponse.
-      // If reconciliation can't identify both sides, any eventual reply would
-      // fail too — skip the callback so the LLM doesn't waste a turn on an
+      // promoted, and to stash both participant ids on the session for
+      // sendResponse. Reconcile failure means the reply would fail too —
+      // skip the callback so the LLM doesn't waste a turn on an
       // un-replyable conversation.
       //
-      // Skip reconcile entirely when both sides are already stashed from a
-      // prior turn — Maestro's state was written by us and doesn't drift.
-      // `authorInfo` is set from the webhook on every turn above; the gate
-      // reads `aiAgentInfo` (persistent across turns) as the signal that
-      // reconcile has already run.
+      // Gate on `aiAgentInfo` (persistent across turns) — `authorInfo` is
+      // overwritten from every webhook so it's not a reliable "already
+      // reconciled" signal.
       if (!session.aiAgentInfo || !session.authorInfo) {
         const resolved = await this.reconcileParticipants(conversationId);
         if (!resolved) {
@@ -492,7 +486,7 @@ export abstract class MessagingChannel extends BaseChannel {
           participantId: agentParticipant.id,
         };
         // When reconcile resolved a customer (SMS path — chat disables customer
-        // reconciliation and uses the author_info captured from the webhook
+        // reconciliation and uses the authorInfo captured from the webhook
         // above), use its authoritative participant id and lift any resolved
         // profile.
         if (customerParticipant && session.authorInfo) {
@@ -893,9 +887,6 @@ export abstract class MessagingChannel extends BaseChannel {
     }
   }
 
-  /**
-   * Unwrap the axios cause from a client-wrapped Error and check for 409.
-   */
   private isConflictError(error: unknown): boolean {
     const cause = error instanceof Error ? (error.cause ?? error) : error;
     return axios.isAxiosError(cause) && cause.response?.status === 409;

--- a/packages/core/src/channels/messaging.ts
+++ b/packages/core/src/channels/messaging.ts
@@ -472,7 +472,10 @@ export abstract class MessagingChannel extends BaseChannel {
       //
       // Skip reconcile entirely when both sides are already stashed from a
       // prior turn — Maestro's state was written by us and doesn't drift.
-      if (!session.aiAgentInfo || !session.authorInfo?.participantId) {
+      // `authorInfo` is set from the webhook on every turn above; the gate
+      // reads `aiAgentInfo` (persistent across turns) as the signal that
+      // reconcile has already run.
+      if (!session.aiAgentInfo || !session.authorInfo) {
         const resolved = await this.reconcileParticipants(conversationId);
         if (!resolved) {
           this.logger.warn(

--- a/packages/core/src/channels/messaging.ts
+++ b/packages/core/src/channels/messaging.ts
@@ -9,10 +9,21 @@ import {
   isConversationId,
   isProfileId,
 } from '../types/index';
+import axios from 'axios';
 import { BaseChannel, BaseChannelEvents } from './base';
 import { ConversationClient } from '../clients/conversation';
 import type { TAC } from '../lib/tac';
 import { maskAddress } from '../util/log-redaction';
+
+/**
+ * Participant types that represent TAC itself at TAC's (channel, address).
+ *
+ * `AI_AGENT` is the canonical type; `AGENT` is the legacy Maestro form. A
+ * participant typed either way at TAC's address is recognized as TAC and not
+ * overwritten; anything else (HUMAN_AGENT, CUSTOMER, …) is someone else's
+ * assignment.
+ */
+const AGENT_TYPES = new Set<string>(['AGENT', 'AI_AGENT']);
 
 /**
  * Messaging webhook event types from Twilio Conversations Service
@@ -79,12 +90,29 @@ export interface MessagingChannelEvents extends BaseChannelEvents {
  *
  * Provides shared webhook processing logic for messaging channels
  * (SMS and Chat) that use the Conversations Service webhooks.
+ *
+ * Subclasses must implement:
+ * - `isDefaultAgentAddress`: fast-path check for the channel's default agent address
+ * - `getAgentAddress`: return the agent's `ConversationAddress` for a conversation
+ * - `sendResponse`: send messages back through the channel
+ *
+ * Subclass flags:
+ * - `reconcileCustomerType`: if `true` (default), reconciliation will also
+ *   promote a channel-matching UNKNOWN participant (not owning the agent
+ *   address) to CUSTOMER. Set `false` for channels where the customer is
+ *   identified author-driven (e.g. chat).
  */
 export abstract class MessagingChannel extends BaseChannel {
   protected override readonly conversationClient: ConversationClient;
   protected readonly messagingCallbacks: MessagingChannelEvents;
   private readonly processedTokens = new Set<string>();
   private readonly maxTrackedTokens: number;
+
+  /**
+   * Controls whether reconciliation promotes an UNKNOWN customer-side
+   * participant to CUSTOMER. Subclasses override to opt out (e.g. chat).
+   */
+  protected reconcileCustomerType: boolean = true;
 
   constructor(tac: TAC, config?: MessagingChannelConfig) {
     super(tac);
@@ -131,34 +159,30 @@ export abstract class MessagingChannel extends BaseChannel {
   protected abstract isDefaultAgentAddress(authorAddress: string): boolean;
 
   /**
-   * Check if a message is from the bot itself.
+   * Return the agent-side ConversationAddress for this conversation.
+   *
+   * Used by `reconcileParticipants` to identify which participant (by channel
+   * + address) represents the agent. May read from session state (e.g. chat's
+   * per-conversation channelId) to build the address.
+   */
+  protected abstract getAgentAddress(conversationId: ConversationId): ConversationAddress;
+
+  /**
+   * Check if a message is from the bot itself (2-tier).
    *
    * 1. Default agent address (stateless, no API call)
-   * 2. Session metadata fromAddress (works same-process for custom `from`)
-   * 3. API lookup: resolve participantId → participant type (works cross-process
-   *    for custom `from` when session is missing, e.g., after restart or on
-   *    another worker)
+   * 2. API fallback via listParticipants (cross-process / multi-worker)
+   *
+   * `HUMAN_AGENT` is deliberately NOT treated as TAC — a real human is a
+   * separate participant and their messages must reach the callback.
    */
   private async isOwnMessage(
     authorAddress: string,
     conversationId: ConversationId,
     authorParticipantId: string | undefined
   ): Promise<boolean> {
-    // Fast path: default agent address
     if (this.isDefaultAgentAddress(authorAddress)) return true;
 
-    // Session path: custom fromAddress stored during outbound initiation
-    const session = this.activeConversations.get(conversationId);
-    if (session?.metadata?.fromAddress === authorAddress) return true;
-
-    // If we have a local session and neither fromAddress nor authorInfo
-    // matches, this is a normal inbound customer message — no API call needed.
-    // The fallback below is only for when there's no session (e.g., webhook
-    // arrived on a different process or after restart for a custom-from
-    // outbound conversation).
-    if (session) return false;
-
-    // Fallback: no local session — look up participant type via API.
     if (authorParticipantId) {
       try {
         const participants = await this.conversationClient.listParticipants(conversationId);
@@ -170,11 +194,7 @@ export abstract class MessagingChannel extends BaseChannel {
               'Participant type is undefined — cannot determine if this is an agent message'
             );
           }
-          if (
-            authorParticipant.type === 'AI_AGENT' ||
-            authorParticipant.type === 'HUMAN_AGENT' ||
-            authorParticipant.type === 'AGENT'
-          ) {
+          if (authorParticipant.type && AGENT_TYPES.has(authorParticipant.type)) {
             return true;
           }
         }
@@ -277,14 +297,6 @@ export abstract class MessagingChannel extends BaseChannel {
           this.handleConversationCreated(webhookData);
           break;
 
-        case 'PARTICIPANT_ADDED':
-          this.logger.debug(
-            { conversation_id: conversationId, profile_id: webhookData.data?.profileId },
-            'Handling PARTICIPANT_ADDED'
-          );
-          this.handleParticipantAdded(webhookData);
-          break;
-
         case 'COMMUNICATION_CREATED':
           this.logger.debug({ conversation_id: conversationId }, 'Handling COMMUNICATION_CREATED');
           await this.handleCommunicationCreated(webhookData);
@@ -339,59 +351,6 @@ export abstract class MessagingChannel extends BaseChannel {
     }
 
     this.startConversation(conversationId, profileId ?? undefined, payload.data?.serviceId);
-  }
-
-  /**
-   * Handle participant added event
-   */
-  private handleParticipantAdded(payload: MessagingWebhookPayload): void {
-    const conversationId = this.extractConversationId(payload);
-    const profileId = this.extractProfileId(payload);
-
-    if (!conversationId) {
-      this.logger.warn(
-        { operation: 'handle_participant_added' },
-        'Missing conversation ID in participant.added event'
-      );
-      throw new Error('Missing conversation ID in participant.added event');
-    }
-
-    // Update conversation with profile ID if conversation exists
-    if (this.isConversationActive(conversationId)) {
-      const session = this.getConversationSession(conversationId);
-      if (session) {
-        if (profileId) {
-          this.logger.debug(
-            {
-              conversation_id: conversationId,
-              old_profile_id: session.profileId,
-              new_profile_id: profileId,
-            },
-            'Updating conversation profile ID from participant.added'
-          );
-          session.profileId = profileId;
-        }
-
-        if (payload.data?.serviceId && session.serviceId !== payload.data.serviceId) {
-          this.logger.debug(
-            {
-              conversation_id: conversationId,
-              old_service_id: session.serviceId,
-              new_service_id: payload.data.serviceId,
-            },
-            'Updating conversation configuration ID from participant.added'
-          );
-          session.serviceId = payload.data.serviceId;
-        }
-      }
-    } else {
-      // Auto-initialize conversation if not already started
-      this.logger.debug(
-        { conversation_id: conversationId, profile_id: profileId },
-        'Auto-starting conversation from participant.added'
-      );
-      this.startConversation(conversationId, profileId ?? undefined, payload.data?.serviceId);
-    }
   }
 
   /**
@@ -503,6 +462,43 @@ export abstract class MessagingChannel extends BaseChannel {
         }
         session.metadata.lastCommunicationId = communicationId;
       }
+
+      // Reconcile participant types pre-LLM so v1-bridge's UNKNOWN gets
+      // promoted to CUSTOMER (with a Memora profile attached when possible)
+      // and to stash both participant ids on the session for sendResponse.
+      // If reconciliation can't identify both sides, any eventual reply would
+      // fail too — skip the callback so the LLM doesn't waste a turn on an
+      // un-replyable conversation.
+      //
+      // Skip reconcile entirely when both sides are already stashed from a
+      // prior turn — Maestro's state was written by us and doesn't drift.
+      if (!session.aiAgentInfo || !session.authorInfo?.participantId) {
+        const resolved = await this.reconcileParticipants(conversationId);
+        if (!resolved) {
+          this.logger.warn(
+            { conversation_id: conversationId },
+            'Reconciliation failed; skipping callback for this inbound'
+          );
+          return;
+        }
+
+        const [agentParticipant, customerParticipant] = resolved;
+        const agentAddress = this.getAgentAddress(conversationId);
+        session.aiAgentInfo = {
+          address: agentAddress.address,
+          participantId: agentParticipant.id,
+        };
+        // When reconcile resolved a customer (SMS path — chat disables customer
+        // reconciliation and uses the author_info captured from the webhook
+        // above), use its authoritative participant id and lift any resolved
+        // profile.
+        if (customerParticipant && session.authorInfo) {
+          session.authorInfo.participantId = customerParticipant.id;
+          if (customerParticipant.profileId && !session.profileId) {
+            session.profileId = customerParticipant.profileId;
+          }
+        }
+      }
     }
 
     // Retrieve user memory using tac.retrieveMemory, which handles profile lookup by address (e.g., phone number or email)
@@ -612,85 +608,302 @@ export abstract class MessagingChannel extends BaseChannel {
   }
 
   /**
-   * Return the conversation's AI_AGENT participant, creating one if absent.
+   * Reconcile Maestro's participants to the types TAC needs for sending.
    *
-   * Returns the first participant in `existingParticipants` whose type is
-   * AI_AGENT / HUMAN_AGENT / AGENT and owns `agentAddress`. If none match,
-   * creates an AI_AGENT with that address. On failure from another worker
-   * creating it concurrently (typically 409), re-lists and re-matches.
+   * v1-bridge capture can leave TAC's agent participant as `UNKNOWN` (wrong
+   * type at our address), or omit it entirely (customer-only conversation).
+   * This pass fixes those cases; it refuses to rewrite anything else at our
+   * address. Decision matrix:
    *
-   * Returns undefined if match-then-create-then-retry all fail. The caller
-   * should log and bail on undefined.
+   *     | Agent side           | Customer side       | Action                        |
+   *     |----------------------|---------------------|-------------------------------|
+   *     | AGENT / AI_AGENT     | CUSTOMER            | Use as-is (no profile work).  |
+   *     | AGENT / AI_AGENT     | UNKNOWN, no CUST    | Resolve profile, PUT → CUST.  |
+   *     | UNKNOWN at our addr  | CUSTOMER            | PUT agent → AI_AGENT.         |
+   *     | UNKNOWN at our addr  | UNKNOWN, no CUST    | PUT agent; resolve, PUT CUST. |
+   *     | other at our addr    | any                 | Return null (log ERROR).      |
+   *     | none at our addr     | CUSTOMER or UNKNOWN | POST AI_AGENT, then proceed.  |
+   *     | any                  | no resolvable cust  | Return null (caller WARNs).   |
+   *
+   * TAC recognizes both `AGENT` and `AI_AGENT` at its address as itself.
+   * `HUMAN_AGENT` is NOT treated as TAC (a real human is a separate
+   * participant — TAC must not speak on their behalf); it falls into the
+   * "other at our addr" row and causes the reconcile to bail.
+   *
+   * Customer-side reconciliation is gated by `reconcileCustomerType`. Chat
+   * sets it to `false` because chat identifies the customer author-driven
+   * (via `session.authorInfo.participantId`), so promoting some other
+   * `UNKNOWN` CHAT participant could pick the wrong recipient.
+   *
+   * @returns `[agent, customerOrNull]` on success. `customer` is `null` when
+   * `reconcileCustomerType` is `false`. `null` overall when either the agent
+   * or the customer cannot be resolved — the caller treats `null` as a hard
+   * stop and skips the message-ready callback.
    */
-  protected async ensureAgentParticipant(
-    conversationId: ConversationId,
-    existingParticipants: ConversationParticipant[],
-    agentAddress: ConversationAddress
-  ): Promise<ConversationParticipant | undefined> {
-    const matches = (p: ConversationParticipant): boolean =>
-      (p.type === 'AI_AGENT' || p.type === 'HUMAN_AGENT' || p.type === 'AGENT') &&
-      Array.isArray(p.addresses) &&
-      p.addresses.some(
-        a => a.channel === agentAddress.channel && a.address === agentAddress.address
-      );
+  protected async reconcileParticipants(
+    conversationId: ConversationId
+  ): Promise<[ConversationParticipant, ConversationParticipant | null] | null> {
+    const agentAddress = this.getAgentAddress(conversationId);
 
-    const existing = existingParticipants.find(matches);
-    if (existing) {
-      return existing;
+    let participants: ConversationParticipant[];
+    try {
+      participants = await this.conversationClient.listParticipants(conversationId);
+    } catch (error) {
+      this.logger.error(
+        { err: error, conversation_id: conversationId },
+        'Failed to list participants for reconciliation'
+      );
+      return null;
     }
 
-    this.logger.debug(
-      {
-        conversation_id: conversationId,
-        channel: agentAddress.channel,
-        address: maskAddress(agentAddress.address),
-      },
-      'No agent participant found, creating AI_AGENT'
+    const channel = agentAddress.channel;
+
+    const ownsAgentAddress = (p: ConversationParticipant): boolean =>
+      Array.isArray(p.addresses) &&
+      p.addresses.some(a => a.channel === channel && a.address === agentAddress.address);
+
+    const matchesChannel = (p: ConversationParticipant): boolean =>
+      Array.isArray(p.addresses) && p.addresses.some(a => a.channel === channel);
+
+    let agentCandidate = participants.find(ownsAgentAddress);
+    if (!agentCandidate) {
+      const created = await this.addAgentParticipant(conversationId, agentAddress);
+      if (!created) return null;
+      agentCandidate = created;
+    } else if (agentCandidate.type === 'UNKNOWN') {
+      // Only promote UNKNOWN — an already-typed participant at TAC's address
+      // that isn't AGENT/AI_AGENT (e.g., CUSTOMER, HUMAN_AGENT) is someone
+      // else's assignment and must not be overwritten.
+      const promoted = await this.promoteParticipant(conversationId, agentCandidate, 'AI_AGENT');
+      if (!promoted) return null;
+      agentCandidate = promoted;
+    } else if (!agentCandidate.type || !AGENT_TYPES.has(agentCandidate.type)) {
+      this.logger.error(
+        {
+          conversation_id: conversationId,
+          participant_id: agentCandidate.id,
+          participant_type: agentCandidate.type,
+        },
+        "Participant at TAC's address has a conflicting type; refusing to overwrite. " +
+          'Check Maestro participant state — a non-agent participant is holding ' +
+          "TAC's (channel, address)."
+      );
+      return null;
+    }
+
+    if (!this.reconcileCustomerType) {
+      return [agentCandidate, null];
+    }
+
+    const customer = participants.find(
+      p => p.type === 'CUSTOMER' && matchesChannel(p) && !ownsAgentAddress(p)
     );
+    if (customer) {
+      return [agentCandidate, customer];
+    }
+
+    const customerUnknown = participants.find(
+      p => p.type === 'UNKNOWN' && matchesChannel(p) && !ownsAgentAddress(p)
+    );
+    if (customerUnknown) {
+      const profileId = await this.resolveCustomerProfile(customerUnknown, channel);
+      const promotedCustomer = await this.promoteParticipant(
+        conversationId,
+        customerUnknown,
+        'CUSTOMER',
+        profileId
+      );
+      if (promotedCustomer) {
+        return [agentCandidate, promotedCustomer];
+      }
+    }
+
+    this.logger.warn(
+      { conversation_id: conversationId, channel },
+      'No customer participant resolvable; skipping webhook'
+    );
+    return null;
+  }
+
+  /**
+   * Find or mint a Memora profile for a customer being promoted from UNKNOWN.
+   *
+   * Only resolves for phone-based channels (SMS, VOICE). Looks up by phone
+   * identifier first; on miss, creates a new profile using the configured
+   * phone trait group/field. Returns undefined on any failure — the caller
+   * still promotes the participant, just without a `profileId` attached.
+   */
+  private async resolveCustomerProfile(
+    customer: ConversationParticipant,
+    channel: string
+  ): Promise<string | undefined> {
+    if (channel !== 'SMS' && channel !== 'VOICE') return undefined;
+
+    const memoryClient = this.tac.getMemoryClient();
+    if (!memoryClient || !this.tac.getMemoryStoreId()) return undefined;
+
+    const phoneAddress = Array.isArray(customer.addresses)
+      ? (customer.addresses.find(a => a.channel === channel && !!a.address)?.address ?? undefined)
+      : undefined;
+    if (!phoneAddress) return undefined;
 
     try {
-      const agent = await this.conversationClient.addParticipant(
+      const lookup = await memoryClient.lookupProfile('phone', phoneAddress);
+      if (lookup.profiles && lookup.profiles.length > 0) {
+        return lookup.profiles[0];
+      }
+    } catch (error) {
+      this.logger.warn(
+        { err: error, conversation_id: customer.conversationId },
+        'Profile lookup failed during reconciliation; falling back to create'
+      );
+    }
+
+    const memoryConfig = this.config.memoryConfig;
+    const traitGroup = memoryConfig.phoneTraitGroup;
+    const traitField = memoryConfig.phoneTraitField;
+
+    try {
+      return await memoryClient.createProfile({
+        [traitGroup]: { [traitField]: phoneAddress },
+      });
+    } catch (error) {
+      this.logger.warn(
+        { err: error, conversation_id: customer.conversationId },
+        'Profile creation failed during reconciliation; promoting without profile'
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * PUT a participant to `newType`.
+   *
+   * Maestro's PUT is a full-resource replacement, so we pass the existing
+   * `name` and `addresses` back unchanged to avoid wiping them. `profileId`
+   * defaults to the participant's current value; pass a non-undefined override
+   * to attach a newly resolved profile during CUSTOMER reconciliation.
+   *
+   * Returns undefined on any error (including 409). A 409 from Maestro here
+   * means the promotion is structurally blocked — stop and surface it; don't
+   * retry.
+   */
+  private async promoteParticipant(
+    conversationId: ConversationId,
+    participant: ConversationParticipant,
+    newType: 'CUSTOMER' | 'AI_AGENT' | 'HUMAN_AGENT' | 'AGENT',
+    profileId?: string
+  ): Promise<ConversationParticipant | undefined> {
+    const effectiveProfileId = profileId !== undefined ? profileId : participant.profileId;
+    const updateOptions: { name?: string; profileId?: string } = {};
+    if (participant.name !== undefined) updateOptions.name = participant.name;
+    if (effectiveProfileId !== null && effectiveProfileId !== undefined) {
+      updateOptions.profileId = effectiveProfileId;
+    }
+
+    try {
+      const updated = await this.conversationClient.updateParticipant(
+        conversationId,
+        participant.id,
+        newType,
+        participant.addresses,
+        updateOptions
+      );
+      this.logger.debug(
+        {
+          conversation_id: conversationId,
+          participant_id: participant.id,
+          from_type: participant.type,
+          to_type: newType,
+        },
+        'Promoted participant'
+      );
+      return updated;
+    } catch (error) {
+      if (this.isConflictError(error)) {
+        this.logger.warn(
+          {
+            conversation_id: conversationId,
+            participant_id: participant.id,
+            target_type: newType,
+            conflicting_resource_id: this.extractConflictingResourceId(error),
+          },
+          'Maestro returned 409 on participant promotion; skipping — likely a ' +
+            'conflicting conversation or grouping constraint. Check Maestro for ' +
+            'duplicate active conversations.'
+        );
+        return undefined;
+      }
+      this.logger.error(
+        {
+          err: error,
+          conversation_id: conversationId,
+          participant_id: participant.id,
+          target_type: newType,
+        },
+        'Failed to promote participant'
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * POST an `AI_AGENT` participant owning `agentAddress`.
+   *
+   * Returns undefined on any error (including 409). A 409 here means the
+   * address is already owned or the conversation's participant set can't
+   * accept a new AI_AGENT — stop and surface it; don't retry.
+   */
+  private async addAgentParticipant(
+    conversationId: ConversationId,
+    agentAddress: ConversationAddress
+  ): Promise<ConversationParticipant | undefined> {
+    try {
+      const created = await this.conversationClient.addParticipant(
         conversationId,
         [agentAddress],
         'AI_AGENT'
       );
       this.logger.debug(
-        {
-          conversation_id: conversationId,
-          participant_id: agent.id,
-        },
-        'Created AI_AGENT participant'
+        { conversation_id: conversationId, participant_id: created.id },
+        'Added AI_AGENT participant'
       );
-      return agent;
+      return created;
     } catch (error) {
-      // Most likely a 409 race (another worker just created the agent), but
-      // we catch broadly here — log the original error so a real 5xx isn't
-      // hidden by the generic "failed to create or find" log below.
-      this.logger.warn(
-        { err: error, conversation_id: conversationId },
-        'Failed to create AI_AGENT, retrying participant list'
-      );
-    }
-
-    let retried: ConversationParticipant[];
-    try {
-      retried = await this.conversationClient.listParticipants(conversationId);
-    } catch (error) {
+      if (this.isConflictError(error)) {
+        this.logger.warn(
+          {
+            conversation_id: conversationId,
+            conflicting_resource_id: this.extractConflictingResourceId(error),
+          },
+          'Maestro returned 409 on AI_AGENT participant add; skipping — address is ' +
+            "already owned or the conversation can't accept a new AI_AGENT. Check " +
+            'Maestro participant state.'
+        );
+        return undefined;
+      }
       this.logger.error(
         { err: error, conversation_id: conversationId },
-        'Failed to retry listing participants'
+        'Failed to add AI_AGENT participant'
       );
       return undefined;
     }
+  }
 
-    const agent = retried.find(matches);
-    if (!agent) {
-      this.logger.error(
-        { conversation_id: conversationId },
-        'Failed to create or find AI_AGENT participant'
-      );
-    }
-    return agent;
+  /**
+   * Unwrap the axios cause from a client-wrapped Error and check for 409.
+   */
+  private isConflictError(error: unknown): boolean {
+    const cause = error instanceof Error ? (error.cause ?? error) : error;
+    return axios.isAxiosError(cause) && cause.response?.status === 409;
+  }
+
+  private extractConflictingResourceId(error: unknown): string | undefined {
+    const cause = error instanceof Error ? (error.cause ?? error) : error;
+    if (!axios.isAxiosError(cause)) return undefined;
+    const headers = cause.response?.headers as Record<string, string> | undefined;
+    const id = headers?.['x-conflicting-resource-id'];
+    return typeof id === 'string' && id.length > 0 ? id : undefined;
   }
 
   /**
@@ -763,7 +976,8 @@ export abstract class MessagingChannel extends BaseChannel {
 
       const agentParticipant = participants.find(
         p =>
-          (p.type === 'AI_AGENT' || p.type === 'HUMAN_AGENT' || p.type === 'AGENT') &&
+          p.type !== undefined &&
+          AGENT_TYPES.has(p.type) &&
           Array.isArray(p.addresses) &&
           p.addresses.some(
             a =>
@@ -785,11 +999,14 @@ export abstract class MessagingChannel extends BaseChannel {
         address: to,
         participantId: customerParticipant.id,
       };
+      session.aiAgentInfo = {
+        address: fromAddress,
+        participantId: agentParticipant.id,
+      };
       session.metadata = {
         ...session.metadata,
         ...(metadata ?? {}),
         direction: 'outbound',
-        fromAddress,
         ...(channelId ? { channelId } : {}),
       };
 

--- a/packages/core/src/channels/messaging.ts
+++ b/packages/core/src/channels/messaging.ts
@@ -18,10 +18,10 @@ import { maskAddress } from '../util/log-redaction';
 /**
  * Participant types that represent TAC itself at TAC's (channel, address).
  *
- * `AI_AGENT` is the canonical type; `AGENT` is the legacy Maestro form. A
- * participant typed either way at TAC's address is recognized as TAC and not
- * overwritten; anything else (HUMAN_AGENT, CUSTOMER, …) is someone else's
- * assignment.
+ * `AI_AGENT` is the canonical type; `AGENT` is the legacy Conversation
+ * Orchestrator form. A participant typed either way at TAC's address is
+ * recognized as TAC and not overwritten; anything else (HUMAN_AGENT,
+ * CUSTOMER, …) is someone else's assignment.
  */
 const AGENT_TYPES = new Set<string>(['AGENT', 'AI_AGENT']);
 
@@ -605,7 +605,8 @@ export abstract class MessagingChannel extends BaseChannel {
   }
 
   /**
-   * Reconcile Maestro's participants to the types TAC needs for sending.
+   * Reconcile Conversation Orchestrator's participants to the types TAC
+   * needs for sending.
    *
    * v1-bridge capture can leave TAC's agent participant as `UNKNOWN` (wrong
    * type at our address), or omit it entirely (customer-only conversation).
@@ -682,7 +683,7 @@ export abstract class MessagingChannel extends BaseChannel {
           participant_type: agentCandidate.type,
         },
         "Participant at TAC's address has a conflicting type; refusing to overwrite. " +
-          'Check Maestro participant state — a non-agent participant is holding ' +
+          'Check Conversation Orchestrator participant state — a non-agent participant is holding ' +
           "TAC's (channel, address)."
       );
       return null;
@@ -723,7 +724,7 @@ export abstract class MessagingChannel extends BaseChannel {
   }
 
   /**
-   * Find or mint a Memora profile for a customer being promoted from UNKNOWN.
+   * Find or mint a Conversation Memory profile for a customer being promoted from UNKNOWN.
    *
    * Only resolves for phone-based channels (SMS, VOICE). Looks up by phone
    * identifier first; on miss, creates a new profile using the configured
@@ -776,14 +777,15 @@ export abstract class MessagingChannel extends BaseChannel {
   /**
    * PUT a participant to `newType`.
    *
-   * Maestro's PUT is a full-resource replacement, so we pass the existing
-   * `name` and `addresses` back unchanged to avoid wiping them. `profileId`
-   * defaults to the participant's current value; pass a non-undefined override
-   * to attach a newly resolved profile during CUSTOMER reconciliation.
+   * Conversation Orchestrator's PUT is a full-resource replacement, so we
+   * pass the existing `name` and `addresses` back unchanged to avoid wiping
+   * them. `profileId` defaults to the participant's current value; pass a
+   * non-undefined override to attach a newly resolved profile during CUSTOMER
+   * reconciliation.
    *
-   * Returns undefined on any error (including 409). A 409 from Maestro here
-   * means the promotion is structurally blocked — stop and surface it; don't
-   * retry.
+   * Returns undefined on any error (including 409). A 409 from Conversation
+   * Orchestrator here means the promotion is structurally blocked — stop and
+   * surface it; don't retry.
    */
   private async promoteParticipant(
     conversationId: ConversationId,
@@ -825,9 +827,9 @@ export abstract class MessagingChannel extends BaseChannel {
             target_type: newType,
             conflicting_resource_id: this.extractConflictingResourceId(error),
           },
-          'Maestro returned 409 on participant promotion; skipping — likely a ' +
-            'conflicting conversation or grouping constraint. Check Maestro for ' +
-            'duplicate active conversations.'
+          'Conversation Orchestrator returned 409 on participant promotion; skipping — ' +
+            'likely a conflicting conversation or grouping constraint. Check ' +
+            'Conversation Orchestrator for duplicate active conversations.'
         );
         return undefined;
       }
@@ -873,9 +875,9 @@ export abstract class MessagingChannel extends BaseChannel {
             conversation_id: conversationId,
             conflicting_resource_id: this.extractConflictingResourceId(error),
           },
-          'Maestro returned 409 on AI_AGENT participant add; skipping — address is ' +
-            "already owned or the conversation can't accept a new AI_AGENT. Check " +
-            'Maestro participant state.'
+          'Conversation Orchestrator returned 409 on AI_AGENT participant add; skipping — ' +
+            "address is already owned or the conversation can't accept a new AI_AGENT. " +
+            'Check Conversation Orchestrator participant state.'
         );
         return undefined;
       }

--- a/packages/core/src/channels/messaging.ts
+++ b/packages/core/src/channels/messaging.ts
@@ -469,7 +469,7 @@ export abstract class MessagingChannel extends BaseChannel {
       // Gate on `aiAgentInfo` (persistent across turns) — `authorInfo` is
       // overwritten from every webhook so it's not a reliable "already
       // reconciled" signal.
-      if (!session.aiAgentInfo || !session.authorInfo) {
+      if (!session.aiAgentInfo) {
         const resolved = await this.reconcileParticipants(conversationId);
         if (!resolved) {
           this.logger.warn(

--- a/packages/core/src/channels/sms.ts
+++ b/packages/core/src/channels/sms.ts
@@ -1,5 +1,6 @@
 import {
   ChannelType,
+  ConversationAddress,
   ConversationId,
   SendMessageActionRequest,
   InitiateMessagingConversationOptions,
@@ -7,7 +8,7 @@ import {
   InitiateConversationResult,
 } from '../types/index';
 import { MessagingChannel } from './messaging';
-import { maskAddress, maskPhone } from '../util/log-redaction';
+import { maskAddress } from '../util/log-redaction';
 
 /**
  * SMS Channel implementation for Twilio Conversations Service
@@ -24,8 +25,18 @@ export class SMSChannel extends MessagingChannel {
     return authorAddress === this.config.phoneNumber;
   }
 
+  protected getAgentAddress(_conversationId: ConversationId): ConversationAddress {
+    return { channel: 'SMS', address: this.config.phoneNumber };
+  }
+
   /**
    * Send SMS response using the Conversation Orchestrator Actions API (SEND_MESSAGE).
+   *
+   * Reads the agent and customer participant ids stashed on the session by
+   * inbound reconciliation or outbound initiation. Missing ids are a misuse —
+   * `sendResponse` is only expected to be called after an inbound webhook
+   * (COMMUNICATION_CREATED → reconcile) or after `initiateOutboundConversation`,
+   * both of which populate the session.
    */
   public async sendResponse(
     conversationId: ConversationId,
@@ -44,54 +55,20 @@ export class SMSChannel extends MessagingChannel {
     try {
       const session = this.getConversationSession(conversationId);
 
-      if (!session) {
-        throw new Error(`No active session found for conversation ${conversationId}`);
-      }
-
-      if (!session.authorInfo) {
+      if (!session || !session.authorInfo || !session.aiAgentInfo) {
         throw new Error(
-          `No author info found for conversation ${conversationId} - no inbound message received yet`
+          `Unable to send SMS: sendResponse called without a reconciled session for ` +
+            `conversation ${conversationId}. Wait for an inbound webhook or call ` +
+            `initiateOutboundConversation first.`
         );
       }
 
-      const recipientAddress = session.authorInfo.address;
-
-      // Fetch current participants from Conversation Orchestrator
-      const participants = await this.conversationClient.listParticipants(conversationId);
-
-      // Find the CUSTOMER participant by address on the SMS channel
-      let customerParticipantId: string | undefined;
-      for (const p of participants) {
-        if (p.type !== 'CUSTOMER' || !Array.isArray(p.addresses)) continue;
-        const smsAddress = p.addresses.find(
-          a => a.channel === 'SMS' && a.address === recipientAddress
-        );
-        if (smsAddress) {
-          customerParticipantId = p.id;
-          break;
-        }
-      }
-
-      // Use fromAddress from session metadata (set during outbound initiation),
-      // falling back to the configured phone number for inbound conversations
-      const agentAddress =
-        typeof session.metadata?.fromAddress === 'string'
-          ? session.metadata.fromAddress
-          : this.config.phoneNumber;
-
-      const agentParticipant = await this.ensureAgentParticipant(conversationId, participants, {
-        channel: 'SMS',
-        address: agentAddress,
-      });
-      if (!agentParticipant) {
+      const customerParticipantId = session.authorInfo.participantId;
+      const agentParticipantId = session.aiAgentInfo.participantId;
+      if (!customerParticipantId || !agentParticipantId) {
         throw new Error(
-          `Failed to resolve AI_AGENT participant for conversation ${conversationId}`
-        );
-      }
-
-      if (!customerParticipantId) {
-        throw new Error(
-          `Customer participant not found on SMS channel for conversation ${conversationId}`
+          `Unable to send SMS: session for conversation ${conversationId} is missing ` +
+            `participant ids.`
         );
       }
 
@@ -101,10 +78,9 @@ export class SMSChannel extends MessagingChannel {
       this.logger.debug(
         {
           conversation_id: conversationId,
-          recipient_address: maskAddress(recipientAddress),
+          recipient_address: maskAddress(session.authorInfo.address),
           recipient_participant_id: customerParticipantId,
-          agent_participant_id: agentParticipant.id,
-          from_number: maskPhone(agentAddress),
+          agent_participant_id: agentParticipantId,
         },
         'Sending SMS via Actions API'
       );
@@ -114,7 +90,7 @@ export class SMSChannel extends MessagingChannel {
         payload: {
           from: {
             channel: 'SMS',
-            participantId: agentParticipant.id,
+            participantId: agentParticipantId,
           },
           to: [
             {
@@ -130,7 +106,10 @@ export class SMSChannel extends MessagingChannel {
       await this.conversationClient.createAction(conversationId, actionRequest);
 
       this.logger.info(
-        { conversation_id: conversationId, recipient_address: maskAddress(recipientAddress) },
+        {
+          conversation_id: conversationId,
+          recipient_address: maskAddress(session.authorInfo.address),
+        },
         'SMS sent successfully via Actions API'
       );
     } catch (error) {
@@ -149,6 +128,7 @@ export class SMSChannel extends MessagingChannel {
    *
    * Creates a conversation via Conversation Orchestrator, adds customer and
    * agent participants, then sends the initial message via the Actions API.
+   * The sender is always `config.phoneNumber`.
    */
   public async initiateOutboundConversation(
     options: InitiateMessagingConversationOptions
@@ -163,7 +143,7 @@ export class SMSChannel extends MessagingChannel {
     return this.initiateOutboundMessagingConversation({
       channel: 'SMS',
       to: validated.to,
-      from: validated.from ?? this.config.phoneNumber,
+      from: this.config.phoneNumber,
       message: validated.message,
       ...(validated.metadata ? { metadata: validated.metadata } : {}),
     });

--- a/packages/core/src/channels/voice.ts
+++ b/packages/core/src/channels/voice.ts
@@ -634,7 +634,7 @@ export class VoiceChannel extends BaseChannel {
     options: InitiateVoiceConversationOptions
   ): Promise<InitiateVoiceConversationResult> {
     const validated = InitiateVoiceConversationOptionsSchema.parse(options);
-    const fromNumber = validated.from ?? this.config.phoneNumber;
+    const fromNumber = this.config.phoneNumber;
 
     this.logger.info(
       { to: validated.to, from: fromNumber },

--- a/packages/core/src/clients/conversation.ts
+++ b/packages/core/src/clients/conversation.ts
@@ -205,16 +205,16 @@ export class ConversationClient extends BaseClient {
   /**
    * Replace an existing participant.
    *
-   * PUT is a full resource replacement per Maestro spec — any field omitted
-   * from the body is cleared on the server. Callers must pass the current
-   * `addresses` (and `name` if set) to preserve them.
+   * PUT is a full resource replacement per the Conversation Orchestrator spec —
+   * any field omitted from the body is cleared on the server. Callers must pass
+   * the current `addresses` (and `name` if set) to preserve them.
    *
    * @param conversationId - Conversation ID containing the participant
    * @param participantId - Participant ID to update
    * @param participantType - New participant type
    * @param addresses - Current participant addresses (required to avoid wiping)
    * @param options.name - Current participant display name (optional)
-   * @param options.profileId - Memora profile ID to attach (optional)
+   * @param options.profileId - Conversation Memory profile ID to attach (optional)
    * @returns Promise containing the updated participant
    */
   public async updateParticipant(

--- a/packages/core/src/clients/conversation.ts
+++ b/packages/core/src/clients/conversation.ts
@@ -174,13 +174,9 @@ export class ConversationClient extends BaseClient {
   /**
    * Add a participant to a conversation.
    *
-   * Used by `reconcileParticipants` when the v1-bridge emits only the customer
-   * participant on an inbound SMS/chat — TAC adds itself as `AI_AGENT` before
-   * replying.
-   *
    * @param conversationId - The conversation ID
    * @param addresses - Array of participant addresses
-   * @param participantType - Type of participant (e.g., CUSTOMER, AI_AGENT, HUMAN_AGENT, AGENT)
+   * @param participantType - Type of participant (CUSTOMER, AI_AGENT, HUMAN_AGENT, AGENT)
    * @returns Promise containing participant response
    */
   public async addParticipant(
@@ -207,11 +203,11 @@ export class ConversationClient extends BaseClient {
   }
 
   /**
-   * Replace an existing participant (PUT is a full resource replacement per
-   * Maestro spec — any field omitted from the body is cleared on the server).
+   * Replace an existing participant.
    *
-   * Callers must pass the current `addresses` (and `name` if set) to preserve
-   * them. Pass a new `profileId` to attach a profile during reconciliation.
+   * PUT is a full resource replacement per Maestro spec — any field omitted
+   * from the body is cleared on the server. Callers must pass the current
+   * `addresses` (and `name` if set) to preserve them.
    *
    * @param conversationId - Conversation ID containing the participant
    * @param participantId - Participant ID to update

--- a/packages/core/src/clients/conversation.ts
+++ b/packages/core/src/clients/conversation.ts
@@ -172,17 +172,21 @@ export class ConversationClient extends BaseClient {
   }
 
   /**
-   * Add a participant to a conversation
+   * Add a participant to a conversation.
+   *
+   * Used by `reconcileParticipants` when the v1-bridge emits only the customer
+   * participant on an inbound SMS/chat — TAC adds itself as `AI_AGENT` before
+   * replying.
    *
    * @param conversationId - The conversation ID
    * @param addresses - Array of participant addresses
-   * @param participantType - Type of participant (CUSTOMER, AI_AGENT, HUMAN_AGENT)
+   * @param participantType - Type of participant (e.g., CUSTOMER, AI_AGENT, HUMAN_AGENT, AGENT)
    * @returns Promise containing participant response
    */
   public async addParticipant(
     conversationId: string,
     addresses: ConversationAddress[],
-    participantType: 'CUSTOMER' | 'AI_AGENT' | 'HUMAN_AGENT'
+    participantType: 'CUSTOMER' | 'AI_AGENT' | 'HUMAN_AGENT' | 'AGENT'
   ): Promise<ConversationParticipant> {
     const url = `/v2/Conversations/${conversationId}/Participants`;
 
@@ -197,6 +201,52 @@ export class ConversationClient extends BaseClient {
     } catch (error) {
       throw new Error(
         `Failed to add participant: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
+      );
+    }
+  }
+
+  /**
+   * Replace an existing participant (PUT is a full resource replacement per
+   * Maestro spec — any field omitted from the body is cleared on the server).
+   *
+   * Callers must pass the current `addresses` (and `name` if set) to preserve
+   * them. Pass a new `profileId` to attach a profile during reconciliation.
+   *
+   * @param conversationId - Conversation ID containing the participant
+   * @param participantId - Participant ID to update
+   * @param participantType - New participant type
+   * @param addresses - Current participant addresses (required to avoid wiping)
+   * @param options.name - Current participant display name (optional)
+   * @param options.profileId - Memora profile ID to attach (optional)
+   * @returns Promise containing the updated participant
+   */
+  public async updateParticipant(
+    conversationId: string,
+    participantId: string,
+    participantType: 'CUSTOMER' | 'AI_AGENT' | 'HUMAN_AGENT' | 'AGENT',
+    addresses: ConversationAddress[],
+    options?: { name?: string; profileId?: string }
+  ): Promise<ConversationParticipant> {
+    const url = `/v2/Conversations/${conversationId}/Participants/${participantId}`;
+
+    const requestBody: Record<string, unknown> = {
+      type: participantType,
+      addresses,
+    };
+    if (options?.name !== undefined) {
+      requestBody.name = options.name;
+    }
+    if (options?.profileId !== undefined) {
+      requestBody.profileId = options.profileId;
+    }
+
+    try {
+      const data = await this.makeRequest<ConversationParticipant>(url, 'PUT', requestBody);
+      return ConversationParticipantSchema.parse(data);
+    } catch (error) {
+      throw new Error(
+        `Failed to update participant: ${error instanceof Error ? error.message : String(error)}`,
         { cause: error }
       );
     }

--- a/packages/core/src/clients/memory.ts
+++ b/packages/core/src/clients/memory.ts
@@ -173,9 +173,7 @@ export class MemoryClient extends BaseClient {
    * @returns Canonical profile ID (`mem_profile_…`)
    * @throws Error if the API request fails or the response is missing an `id` field
    */
-  public async createProfile(
-    traits: Record<string, Record<string, unknown>>
-  ): Promise<string> {
+  public async createProfile(traits: Record<string, Record<string, unknown>>): Promise<string> {
     const url = `/v1/Stores/${this.storeId}/Profiles`;
     const requestBody = { traits };
 

--- a/packages/core/src/clients/memory.ts
+++ b/packages/core/src/clients/memory.ts
@@ -159,7 +159,7 @@ export class MemoryClient extends BaseClient {
   /**
    * Create a profile via identity resolution (upsert).
    *
-   * Memora runs identity resolution on the submitted traits: if an identifier
+   * Conversation Memory runs identity resolution on the submitted traits: if an identifier
    * match is found, the existing canonical profile ID is returned; otherwise a
    * new profile is minted. The body must contain at least one
    * trait-promoted-to-identifier per the store's identity resolution settings,

--- a/packages/core/src/clients/memory.ts
+++ b/packages/core/src/clients/memory.ts
@@ -157,6 +157,47 @@ export class MemoryClient extends BaseClient {
   }
 
   /**
+   * Create a profile via identity resolution (upsert).
+   *
+   * Memora runs identity resolution on the submitted traits: if an identifier
+   * match is found, the existing canonical profile ID is returned; otherwise a
+   * new profile is minted. The body must contain at least one
+   * trait-promoted-to-identifier per the store's identity resolution settings,
+   * else resolution fails with 400.
+   *
+   * The write is queued (202 Accepted) — the canonical profile ID is returned
+   * synchronously in the response body, but downstream traits may not be fully
+   * persisted immediately.
+   *
+   * @param traits - Trait-group → field → value mapping (e.g. `{"Contact": {"phone": "+13175551234"}}`)
+   * @returns Canonical profile ID (`mem_profile_…`)
+   * @throws Error if the API request fails or the response is missing an `id` field
+   */
+  public async createProfile(
+    traits: Record<string, Record<string, unknown>>
+  ): Promise<string> {
+    const url = `/v1/Stores/${this.storeId}/Profiles`;
+    const requestBody = { traits };
+
+    let data: unknown;
+    try {
+      data = await this.makeRequest<unknown>(url, 'POST', requestBody);
+    } catch (error) {
+      throw new Error(
+        `Failed to create profile: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
+      );
+    }
+
+    const profileId =
+      data && typeof data === 'object' && 'id' in data ? (data as { id: unknown }).id : undefined;
+    if (typeof profileId !== 'string') {
+      throw new Error(`CreateProfile response missing 'id' field: ${JSON.stringify(data)}`);
+    }
+    return profileId;
+  }
+
+  /**
    * Fetch profile information with traits
    *
    * @param profileId - The profile ID to fetch

--- a/packages/core/src/lib/config.ts
+++ b/packages/core/src/lib/config.ts
@@ -220,8 +220,10 @@ export class TACConfig {
           0.0,
           1.0
         ),
-        phoneTraitGroup: process.env[EnvironmentVariables.TWILIO_MEMORY_PHONE_TRAIT_GROUP],
-        phoneTraitField: process.env[EnvironmentVariables.TWILIO_MEMORY_PHONE_TRAIT_FIELD],
+        phoneTraitGroup:
+          process.env[EnvironmentVariables.TWILIO_MEMORY_PHONE_TRAIT_GROUP] || undefined,
+        phoneTraitField:
+          process.env[EnvironmentVariables.TWILIO_MEMORY_PHONE_TRAIT_FIELD] || undefined,
       },
       conversationConfigurationId:
         process.env[EnvironmentVariables.TWILIO_CONVERSATION_CONFIGURATION_ID] || undefined,

--- a/packages/core/src/lib/config.ts
+++ b/packages/core/src/lib/config.ts
@@ -95,6 +95,8 @@ export class TACConfig {
    * - TWILIO_MEMORY_SUMMARIES_LIMIT: Max summaries in memory retrieval
    * - TWILIO_MEMORY_COMMUNICATIONS_LIMIT: Max communications in memory retrieval
    * - TWILIO_MEMORY_RELEVANCE_THRESHOLD: Min relevance score (0.0-1.0)
+   * - TWILIO_MEMORY_PHONE_TRAIT_GROUP: Trait group that holds the phone identifier on new profiles (default "Contact")
+   * - TWILIO_MEMORY_PHONE_TRAIT_FIELD: Trait field within phoneTraitGroup (default "phone")
    *
    * @throws Error if required environment variables are not set or invalid
    *
@@ -218,6 +220,8 @@ export class TACConfig {
           0.0,
           1.0
         ),
+        phoneTraitGroup: process.env[EnvironmentVariables.TWILIO_MEMORY_PHONE_TRAIT_GROUP],
+        phoneTraitField: process.env[EnvironmentVariables.TWILIO_MEMORY_PHONE_TRAIT_FIELD],
       },
       conversationConfigurationId:
         process.env[EnvironmentVariables.TWILIO_CONVERSATION_CONFIGURATION_ID] || undefined,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -16,6 +16,13 @@ export const TwilioMemoryConfigSchema = z.object({
   // API default is 0 (no communications fetched). SDK defaults to 10 for a useful out-of-box experience.
   communicationsLimit: z.number().int().min(0).max(100).default(10),
   relevanceThreshold: z.number().min(0.0).max(1.0).default(0.0),
+  /**
+   * Trait group name that holds the phone identifier on newly created profiles.
+   * Must match the promoted-to-identifier configuration of the Memora store.
+   */
+  phoneTraitGroup: z.string().default('Contact'),
+  /** Trait field name within `phoneTraitGroup` that holds the phone identifier. */
+  phoneTraitField: z.string().default('phone'),
 });
 
 export type TwilioMemoryConfig = z.infer<typeof TwilioMemoryConfigSchema>;
@@ -76,6 +83,8 @@ export const EnvironmentVariables = {
   TWILIO_MEMORY_SUMMARIES_LIMIT: 'TWILIO_MEMORY_SUMMARIES_LIMIT',
   TWILIO_MEMORY_COMMUNICATIONS_LIMIT: 'TWILIO_MEMORY_COMMUNICATIONS_LIMIT',
   TWILIO_MEMORY_RELEVANCE_THRESHOLD: 'TWILIO_MEMORY_RELEVANCE_THRESHOLD',
+  TWILIO_MEMORY_PHONE_TRAIT_GROUP: 'TWILIO_MEMORY_PHONE_TRAIT_GROUP',
+  TWILIO_MEMORY_PHONE_TRAIT_FIELD: 'TWILIO_MEMORY_PHONE_TRAIT_FIELD',
   TWILIO_CONVERSATION_CONFIGURATION_ID: 'TWILIO_CONVERSATION_CONFIGURATION_ID',
   VOICE_PUBLIC_DOMAIN: 'VOICE_PUBLIC_DOMAIN',
   TWILIO_TAC_CI_CONFIGURATION_ID: 'TWILIO_TAC_CI_CONFIGURATION_ID',

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -18,7 +18,7 @@ export const TwilioMemoryConfigSchema = z.object({
   relevanceThreshold: z.number().min(0.0).max(1.0).default(0.0),
   /**
    * Trait group name that holds the phone identifier on newly created profiles.
-   * Must match the promoted-to-identifier configuration of the Memora store.
+   * Must match the promoted-to-identifier configuration of the Conversation Memory store.
    */
   phoneTraitGroup: z.string().default('Contact'),
   /** Trait field name within `phoneTraitGroup` that holds the phone identifier. */

--- a/packages/core/src/types/conversation.ts
+++ b/packages/core/src/types/conversation.ts
@@ -225,6 +225,12 @@ export const ConversationSessionSchema = z.object({
   channel: ChannelTypeSchema,
   startedAt: z.date(),
   authorInfo: AuthorInfoSchema.optional(),
+  /**
+   * Agent-side participant info stashed by inbound reconciliation or outbound
+   * initiation. `sendResponse` reads this to avoid re-listing participants at
+   * send time. Missing means reconciliation did not resolve an AI_AGENT.
+   */
+  aiAgentInfo: AuthorInfoSchema.optional(),
   profile: z.custom<Profile>().optional(),
   metadata: z.record(z.unknown()).optional().default({}),
   /**
@@ -428,11 +434,14 @@ export type ConversationConfiguration = z.infer<typeof ConversationConfiguration
 // =========================================================================
 
 /**
- * Options for initiating an outbound SMS conversation
+ * Options for initiating an outbound SMS conversation.
+ *
+ * The sender is always TAC's configured `config.phoneNumber`. Multi-sender
+ * deployments should run one TAC instance per sender so inbound webhook
+ * routing, memory scoping, and configuration stay in sync.
  */
 export const InitiateMessagingConversationOptionsSchema = z.object({
   to: z.string().min(1, 'Recipient address is required'),
-  from: z.string().optional(),
   message: z.string().min(1, 'Initial message is required'),
   metadata: z.record(z.unknown()).optional(),
 });

--- a/packages/core/src/types/conversation.ts
+++ b/packages/core/src/types/conversation.ts
@@ -228,7 +228,7 @@ export const ConversationSessionSchema = z.object({
   /**
    * Agent-side participant info stashed by inbound reconciliation or outbound
    * initiation. `sendResponse` reads this to avoid re-listing participants at
-   * send time. Missing means reconciliation did not resolve an AI_AGENT.
+   * send time.
    */
   aiAgentInfo: AuthorInfoSchema.optional(),
   profile: z.custom<Profile>().optional(),

--- a/packages/core/src/types/crelay.ts
+++ b/packages/core/src/types/crelay.ts
@@ -282,11 +282,13 @@ export type ConversationRelayCallbackPayload = z.infer<
 // =========================================================================
 
 /**
- * Options for initiating an outbound voice conversation
+ * Options for initiating an outbound voice conversation.
+ *
+ * The caller identity is always TAC's configured `config.phoneNumber`.
+ * Multi-number deployments should run one TAC instance per line.
  */
 export interface InitiateVoiceConversationOptions {
   to: string;
-  from?: string | undefined;
   conversationRelayConfig: ConversationRelayConfig;
   actionUrl?: string | undefined;
 }
@@ -294,7 +296,6 @@ export interface InitiateVoiceConversationOptions {
 export const InitiateVoiceConversationOptionsSchema: z.ZodType<InitiateVoiceConversationOptions> =
   z.object({
     to: z.string().min(1, 'Recipient phone number is required'),
-    from: z.string().optional(),
     conversationRelayConfig: ConversationRelayConfigSchema,
     actionUrl: z.string().url().optional(),
   });

--- a/tests/chat-channel.test.ts
+++ b/tests/chat-channel.test.ts
@@ -30,6 +30,20 @@ describe('Chat Channel', () => {
     // Short-circuit memory retrieval so webhook processing tests don't hit
     // real Twilio APIs with fake credentials and spam the logs with 401s.
     vi.spyOn(tac, 'retrieveMemory').mockResolvedValue(undefined as never);
+    // Short-circuit reconcileParticipants so webhook processing tests don't
+    // need to mock listParticipants. Chat disables customer reconcile so the
+    // second element is null. Tests that care about reconcile behavior should
+    // override this spy.
+    vi.spyOn(channel as any, 'reconcileParticipants').mockResolvedValue([
+      {
+        id: 'PA_agent_123',
+        conversationId: 'CHtest123456789',
+        accountId: 'ACtest123456789',
+        type: 'AI_AGENT',
+        addresses: [{ channel: 'CHAT', address: 'ai-assistant' }],
+      },
+      null,
+    ]);
   });
 
   describe('initialization', () => {
@@ -233,68 +247,58 @@ describe('Chat Channel', () => {
   });
 
   describe('send response', () => {
+    /**
+     * Pre-populate a fully-reconciled chat session. `sendResponse` now reads
+     * ids directly from `session.authorInfo` and `session.aiAgentInfo`; it no
+     * longer calls `listParticipants`/`addParticipant` at send time.
+     */
+    const seedReconciledSession = (conversationId: string, opts?: {
+      channelId?: string;
+      agentParticipantId?: string;
+      customerParticipantId?: string;
+    }) => {
+      (channel as any).activeConversations.set(conversationId, {
+        conversationId,
+        channel: 'chat',
+        startedAt: new Date(),
+        authorInfo: {
+          address: 'customer@example.com',
+          participantId: opts?.customerParticipantId ?? 'PA_customer_123',
+        },
+        aiAgentInfo: {
+          address: 'ai-assistant',
+          participantId: opts?.agentParticipantId ?? 'PA_agent_123',
+        },
+        metadata: opts?.channelId ? { channelId: opts.channelId } : {},
+      });
+    };
+
     beforeEach(() => {
       // Access the conversation client's axios instance through TAC
       const conversationClient = (tac as any).conversationClient;
       mockAdapter = new MockAdapter(conversationClient.axiosInstance);
       // Reset history to clear the getConfiguration call from TAC initialization
       mockAdapter.resetHistory();
-    });
 
-    it('should send response via Actions API with existing AI_AGENT', async () => {
-      // Start conversation, then receive message to populate session
-      await channel.processWebhook({
-        eventType: 'CONVERSATION_CREATED',
-        data: { conversationId: 'CHtest123456789' },
-      });
-
-      await channel.processWebhook({
-        eventType: 'COMMUNICATION_CREATED',
-        data: {
-          conversationId: 'CHtest123456789',
-          author: {
-            address: 'customer@example.com',
-            participantId: 'PA_customer_123',
-            channel: 'CHAT',
-          },
-          content: { type: 'TEXT', text: 'Hello' },
-          channelId: 'CH00000000000000000000000000000000',
-        },
-      });
-
-      // Mock listParticipants (AI_AGENT exists)
-      mockAdapter.onGet('/v2/Conversations/CHtest123456789/Participants').reply(200, {
-        participants: [
-          {
-            id: 'PA_agent_123',
-            conversationId: 'CHtest123456789',
-            accountId: 'ACtest123456789',
-            type: 'AI_AGENT',
-            addresses: [{ channel: 'CHAT', address: 'ai-assistant' }],
-          },
-          {
-            id: 'PA_customer_123',
-            conversationId: 'CHtest123456789',
-            accountId: 'ACtest123456789',
-            type: 'CUSTOMER',
-            addresses: [{ channel: 'CHAT', address: 'customer@example.com' }],
-          },
-        ],
-      });
-
-      // Mock createAction
+      // Mock createAction. sendResponse no longer lists participants.
       mockAdapter.onPost('/v2/Conversations/CHtest123456789/Actions').reply(202, {
         id: 'conv_action_01abcdef',
         type: 'SEND_MESSAGE',
         status: 'PENDING',
         conversationId: 'CHtest123456789',
       });
+    });
+
+    it('should send response via Actions API', async () => {
+      seedReconciledSession('CHtest123456789', {
+        channelId: 'CH00000000000000000000000000000000',
+      });
 
       await channel.sendResponse('CHtest123456789', 'Hello from bot');
 
-      // Verify requests (listParticipants + createAction)
+      // sendResponse no longer calls listParticipants — only createAction
       const history = mockAdapter.history;
-      expect(history.get.length).toBe(1); // listParticipants
+      expect(history.get.length).toBe(0);
       expect(history.post.length).toBe(1);
       expect(history.post[0]!.url).toBe('/v2/Conversations/CHtest123456789/Actions');
       const body = JSON.parse(history.post[0]!.data);
@@ -318,44 +322,8 @@ describe('Chat Channel', () => {
       // TODO(conv-orch): Drop this test when the chatService workaround is removed.
       tac.conversationsV1ServiceSid = 'ISabcdef1234567890abcdef1234567890';
 
-      await channel.processWebhook({
-        eventType: 'COMMUNICATION_CREATED',
-        data: {
-          conversationId: 'CHtest123456789',
-          author: {
-            address: 'customer@example.com',
-            participantId: 'PA_customer_123',
-            channel: 'CHAT',
-          },
-          content: { type: 'TEXT', text: 'Hello' },
-          channelId: 'CH00000000000000000000000000000000',
-        },
-      });
-
-      mockAdapter.onGet('/v2/Conversations/CHtest123456789/Participants').reply(200, {
-        participants: [
-          {
-            id: 'PA_agent_123',
-            conversationId: 'CHtest123456789',
-            accountId: 'ACtest123456789',
-            type: 'AI_AGENT',
-            addresses: [{ channel: 'CHAT', address: 'ai-assistant' }],
-          },
-          {
-            id: 'PA_customer_123',
-            conversationId: 'CHtest123456789',
-            accountId: 'ACtest123456789',
-            type: 'CUSTOMER',
-            addresses: [{ channel: 'CHAT', address: 'customer@example.com' }],
-          },
-        ],
-      });
-
-      mockAdapter.onPost('/v2/Conversations/CHtest123456789/Actions').reply(202, {
-        id: 'conv_action_01abcdef',
-        type: 'SEND_MESSAGE',
-        status: 'PENDING',
-        conversationId: 'CHtest123456789',
+      seedReconciledSession('CHtest123456789', {
+        channelId: 'CH00000000000000000000000000000000',
       });
 
       await channel.sendResponse('CHtest123456789', 'Hello');
@@ -370,223 +338,44 @@ describe('Chat Channel', () => {
     });
 
     it('should throw when channelId missing from session metadata', async () => {
-      // Seed a session with inbound but no channelId
-      await channel.processWebhook({
-        eventType: 'COMMUNICATION_CREATED',
-        data: {
-          conversationId: 'CHtest123456789',
-          author: {
-            address: 'customer@example.com',
-            participantId: 'PA_customer_123',
-            channel: 'CHAT',
-          },
-          content: { type: 'TEXT', text: 'Hello' },
-          // no channelId
-        },
-      });
+      // Seed a reconciled session but without channelId
+      seedReconciledSession('CHtest123456789');
 
       await expect(channel.sendResponse('CHtest123456789', 'Hello')).rejects.toThrow(
         /session\.metadata\['channelId'\]/
       );
     });
 
-    it('should create AI_AGENT participant if not exists', async () => {
-      await channel.processWebhook({
-        eventType: 'CONVERSATION_CREATED',
-        data: { conversationId: 'CHtest123456789' },
-      });
-
-      await channel.processWebhook({
-        eventType: 'COMMUNICATION_CREATED',
-        data: {
-          conversationId: 'CHtest123456789',
-          author: {
-            address: 'customer@example.com',
-            participantId: 'PA_customer_123',
-            channel: 'CHAT',
-          },
-          content: { type: 'TEXT', text: 'Hello' },
-          channelId: 'CH00000000000000000000000000000000',
-        },
-      });
-
-      // Mock listParticipants (no AI_AGENT)
-      mockAdapter.onGet('/v2/Conversations/CHtest123456789/Participants').reply(200, {
-        participants: [
-          {
-            id: 'PA_customer_123',
-            conversationId: 'CHtest123456789',
-            accountId: 'ACtest123456789',
-            type: 'CUSTOMER',
-            addresses: [{ channel: 'CHAT', address: 'customer@example.com' }],
-          },
-        ],
-      });
-
-      // Mock addParticipant
-      mockAdapter.onPost('/v2/Conversations/CHtest123456789/Participants').reply(201, {
-        id: 'PA_agent_123',
-        conversationId: 'CHtest123456789',
-        accountId: 'ACtest123456789',
-        type: 'AI_AGENT',
-        addresses: [{ channel: 'CHAT', address: 'ai-assistant' }],
-      });
-
-      // Mock createAction
-      mockAdapter.onPost('/v2/Conversations/CHtest123456789/Actions').reply(202, {
-        id: 'conv_action_01abcdef',
-        type: 'SEND_MESSAGE',
-        status: 'PENDING',
-        conversationId: 'CHtest123456789',
-      });
-
-      await channel.sendResponse('CHtest123456789', 'Hello from bot');
-
-      // Verify requests (listParticipants + addParticipant + createAction)
-      const history = mockAdapter.history;
-      expect(history.get.length).toBe(1); // listParticipants
-      expect(history.post.length).toBe(2); // addParticipant + createAction
-
-      // Verify addParticipant call
-      const addCall = history.post.find(p => p.url?.endsWith('/Participants'));
-      expect(addCall).toBeDefined();
-      const addBody = JSON.parse(addCall!.data);
-      expect(addBody).toMatchObject({
-        type: 'AI_AGENT',
-        addresses: [
-          {
-            channel: 'CHAT',
-            address: 'ai-assistant',
-            channelId: 'CH00000000000000000000000000000000',
-          },
-        ],
-      });
-    });
-
-    it('should handle race condition when creating AI_AGENT', async () => {
-      await channel.processWebhook({
-        eventType: 'CONVERSATION_CREATED',
-        data: { conversationId: 'CHtest123456789' },
-      });
-
-      await channel.processWebhook({
-        eventType: 'COMMUNICATION_CREATED',
-        data: {
-          conversationId: 'CHtest123456789',
-          author: {
-            address: 'customer@example.com',
-            participantId: 'PA_customer_123',
-            channel: 'CHAT',
-          },
-          content: { type: 'TEXT', text: 'Hello' },
-          channelId: 'CH00000000000000000000000000000000',
-        },
-      });
-
-      // Mock listParticipants - first call returns no AI_AGENT, second call returns AI_AGENT
-      mockAdapter
-        .onGet('/v2/Conversations/CHtest123456789/Participants')
-        .replyOnce(200, {
-          participants: [
-            {
-              id: 'PA_customer_123',
-              conversationId: 'CHtest123456789',
-              accountId: 'ACtest123456789',
-              type: 'CUSTOMER',
-              addresses: [{ channel: 'CHAT', address: 'customer@example.com' }],
-            },
-          ],
-        })
-        .onGet('/v2/Conversations/CHtest123456789/Participants')
-        .replyOnce(200, {
-          participants: [
-            {
-              id: 'PA_agent_123',
-              conversationId: 'CHtest123456789',
-              accountId: 'ACtest123456789',
-              type: 'AI_AGENT',
-              addresses: [{ channel: 'CHAT', address: 'ai-assistant' }],
-            },
-            {
-              id: 'PA_customer_123',
-              conversationId: 'CHtest123456789',
-              accountId: 'ACtest123456789',
-              type: 'CUSTOMER',
-              addresses: [{ channel: 'CHAT', address: 'customer@example.com' }],
-            },
-          ],
-        });
-
-      // Mock addParticipant failure (already exists)
-      mockAdapter.onPost('/v2/Conversations/CHtest123456789/Participants').reply(409, {
-        error: 'Participant already exists',
-      });
-
-      // Mock createAction
-      mockAdapter.onPost('/v2/Conversations/CHtest123456789/Actions').reply(202, {
-        id: 'conv_action_01abcdef',
-        type: 'SEND_MESSAGE',
-        status: 'PENDING',
-        conversationId: 'CHtest123456789',
-      });
-
-      await channel.sendResponse('CHtest123456789', 'Hello from bot');
-
-      // Verify requests: 2x listParticipants + addParticipant + createAction
-      const history = mockAdapter.history;
-      expect(history.get.length).toBe(2); // 2x listParticipants (retry after 409)
-      expect(history.post.length).toBe(2); // addParticipant + createAction
-    });
-
-    it('should throw when ensureAgentParticipant fails (addParticipant fails and retry finds none)', async () => {
-      await channel.processWebhook({
-        eventType: 'COMMUNICATION_CREATED',
-        data: {
-          conversationId: 'CHtest123456789',
-          author: {
-            address: 'customer@example.com',
-            participantId: 'PA_customer_123',
-            channel: 'CHAT',
-          },
-          content: { type: 'TEXT', text: 'Hello' },
-          channelId: 'CH00000000000000000000000000000000',
-        },
-      });
-
-      // Both list calls return no AI_AGENT; addParticipant also fails
-      mockAdapter.onGet('/v2/Conversations/CHtest123456789/Participants').reply(200, {
-        participants: [
-          {
-            id: 'PA_customer_123',
-            conversationId: 'CHtest123456789',
-            accountId: 'ACtest123456789',
-            type: 'CUSTOMER',
-            addresses: [{ channel: 'CHAT', address: 'customer@example.com' }],
-          },
-        ],
-      });
-      mockAdapter.onPost('/v2/Conversations/CHtest123456789/Participants').reply(500);
-
+    it('should throw when no session exists', async () => {
       await expect(channel.sendResponse('CHtest123456789', 'Hello')).rejects.toThrow(
-        'Failed to resolve AI_AGENT participant'
+        'without a reconciled session'
       );
     });
 
-    it('should throw error if no active session', async () => {
-      await expect(channel.sendResponse('CHtest123456789', 'Hello')).rejects.toThrow(
-        'No active session found'
-      );
-    });
-
-    it('should throw error if no author info', async () => {
-      // Create conversation without author info
-      await channel.processWebhook({
-        eventType: 'CONVERSATION_CREATED',
-        data: { conversationId: 'CHtest123456789' },
+    it('should throw when session is missing authorInfo', async () => {
+      (channel as any).activeConversations.set('CHtest123456789', {
+        conversationId: 'CHtest123456789',
+        channel: 'chat',
+        startedAt: new Date(),
+        metadata: {},
       });
 
       await expect(channel.sendResponse('CHtest123456789', 'Hello')).rejects.toThrow(
-        'No author info found'
+        'without a reconciled session'
+      );
+    });
+
+    it('should throw when session is missing aiAgentInfo', async () => {
+      (channel as any).activeConversations.set('CHtest123456789', {
+        conversationId: 'CHtest123456789',
+        channel: 'chat',
+        startedAt: new Date(),
+        authorInfo: { address: 'customer@example.com', participantId: 'PA_customer_123' },
+        metadata: {},
+      });
+
+      await expect(channel.sendResponse('CHtest123456789', 'Hello')).rejects.toThrow(
+        'without a reconciled session'
       );
     });
   });

--- a/tests/conversation-client.test.ts
+++ b/tests/conversation-client.test.ts
@@ -158,6 +158,110 @@ describe('ConversationClient', () => {
     });
   });
 
+  describe('updateParticipant()', () => {
+    it('should PUT participant with type and addresses', async () => {
+      const mockResponse = {
+        id: 'part_123',
+        conversationId: 'CH123',
+        accountId: 'AC123456',
+        type: 'AI_AGENT',
+        addresses: [{ channel: 'SMS', address: '+12025551234' }],
+      };
+
+      mockAdapter
+        .onPut('/v2/Conversations/CH123/Participants/part_123')
+        .reply(200, mockResponse);
+
+      const result = await conversationClient.updateParticipant(
+        'CH123',
+        'part_123',
+        'AI_AGENT',
+        [{ channel: 'SMS', address: '+12025551234' }]
+      );
+
+      expect(result.id).toBe('part_123');
+      expect(result.type).toBe('AI_AGENT');
+
+      const body = JSON.parse(mockAdapter.history.put[0]!.data);
+      expect(body).toMatchObject({
+        type: 'AI_AGENT',
+        addresses: [{ channel: 'SMS', address: '+12025551234' }],
+      });
+      expect(body).not.toHaveProperty('name');
+      expect(body).not.toHaveProperty('profileId');
+    });
+
+    it('should include optional name and profileId when provided', async () => {
+      const mockResponse = {
+        id: 'part_123',
+        conversationId: 'CH123',
+        accountId: 'AC123456',
+        type: 'CUSTOMER',
+        addresses: [{ channel: 'SMS', address: '+12025551234' }],
+        name: 'Jane Customer',
+        profileId: 'mem_profile_00000000000000000000000001',
+      };
+
+      mockAdapter
+        .onPut('/v2/Conversations/CH123/Participants/part_123')
+        .reply(200, mockResponse);
+
+      await conversationClient.updateParticipant(
+        'CH123',
+        'part_123',
+        'CUSTOMER',
+        [{ channel: 'SMS', address: '+12025551234' }],
+        { name: 'Jane Customer', profileId: 'mem_profile_00000000000000000000000001' }
+      );
+
+      const body = JSON.parse(mockAdapter.history.put[0]!.data);
+      expect(body).toMatchObject({
+        type: 'CUSTOMER',
+        addresses: [{ channel: 'SMS', address: '+12025551234' }],
+        name: 'Jane Customer',
+        profileId: 'mem_profile_00000000000000000000000001',
+      });
+    });
+
+    it('should include participantId in URL path', async () => {
+      mockAdapter
+        .onPut('/v2/Conversations/CH123/Participants/part_xyz789')
+        .reply(200, {
+          id: 'part_xyz789',
+          conversationId: 'CH123',
+          accountId: 'AC123456',
+          type: 'AI_AGENT',
+          addresses: [{ channel: 'SMS', address: '+12025551234' }],
+        });
+
+      await conversationClient.updateParticipant(
+        'CH123',
+        'part_xyz789',
+        'AI_AGENT',
+        [{ channel: 'SMS', address: '+12025551234' }]
+      );
+
+      expect(mockAdapter.history.put[0]!.url).toBe(
+        '/v2/Conversations/CH123/Participants/part_xyz789'
+      );
+    });
+
+    it('should surface HTTP errors', async () => {
+      mockAdapter
+        .onPut('/v2/Conversations/CH123/Participants/part_123')
+        .reply(500);
+
+      await expect(
+        conversationClient.updateParticipant(
+          'CH123',
+          'part_123',
+          'AI_AGENT',
+          [{ channel: 'SMS', address: '+12025551234' }]
+        )
+      ).rejects.toThrow(/Failed to update participant/);
+    });
+  });
+
   describe('listConversations()', () => {
     it('should list conversations by channelId', async () => {
       const mockResponse = {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -82,6 +82,26 @@ describe('Integration Tests', () => {
       communications: [],
     } as never);
     vi.spyOn(tac.getConversationClient(), 'listCommunications').mockResolvedValue([]);
+    // reconcileParticipants uses axios under the hood — short-circuit it so
+    // inbound webhook processing reaches the message-ready callback.
+    vi.spyOn(channel as any, 'reconcileParticipants').mockImplementation(
+      async (convId: unknown) => [
+        {
+          id: 'PA111',
+          conversationId: convId,
+          accountId: 'ACtest123456789',
+          type: 'AI_AGENT',
+          addresses: [{ channel: 'SMS', address: '+15551234567' }],
+        },
+        {
+          id: 'PA222',
+          conversationId: convId,
+          accountId: 'ACtest123456789',
+          type: 'CUSTOMER',
+          addresses: [{ channel: 'SMS', address: '+15559876543' }],
+        },
+      ]
+    );
   });
 
   afterEach(() => {

--- a/tests/memory-client.test.ts
+++ b/tests/memory-client.test.ts
@@ -117,10 +117,9 @@ describe('MemoryClient', () => {
         .onPost('/v1/Stores/mem_service_01kbjqhhdpft0tbp21jt4ktbxg/Profiles')
         .reply(202, { id: 'mem_profile_00000000000000000000000001' });
 
-      const result = await memoryClient.createProfile(
-        'mem_service_01kbjqhhdpft0tbp21jt4ktbxg',
-        { Contact: { phone: '+13175551234' } }
-      );
+      const result = await memoryClient.createProfile({
+        Contact: { phone: '+13175551234' },
+      });
 
       expect(result).toBe('mem_profile_00000000000000000000000001');
 
@@ -136,9 +135,7 @@ describe('MemoryClient', () => {
         .reply(202, { foo: 'bar' });
 
       await expect(
-        memoryClient.createProfile('mem_service_01kbjqhhdpft0tbp21jt4ktbxg', {
-          Contact: { phone: '+13175551234' },
-        })
+        memoryClient.createProfile({ Contact: { phone: '+13175551234' } })
       ).rejects.toThrow(/CreateProfile response missing 'id' field/);
     });
 
@@ -148,9 +145,7 @@ describe('MemoryClient', () => {
         .reply(500);
 
       await expect(
-        memoryClient.createProfile('mem_service_01kbjqhhdpft0tbp21jt4ktbxg', {
-          Contact: { phone: '+13175551234' },
-        })
+        memoryClient.createProfile({ Contact: { phone: '+13175551234' } })
       ).rejects.toThrow(/Failed to create profile/);
     });
   });

--- a/tests/memory-client.test.ts
+++ b/tests/memory-client.test.ts
@@ -111,6 +111,50 @@ describe('MemoryClient', () => {
     });
   });
 
+  describe('createProfile()', () => {
+    it('should POST traits to /Profiles and return the id', async () => {
+      mockAdapter
+        .onPost('/v1/Stores/mem_service_01kbjqhhdpft0tbp21jt4ktbxg/Profiles')
+        .reply(202, { id: 'mem_profile_00000000000000000000000001' });
+
+      const result = await memoryClient.createProfile(
+        'mem_service_01kbjqhhdpft0tbp21jt4ktbxg',
+        { Contact: { phone: '+13175551234' } }
+      );
+
+      expect(result).toBe('mem_profile_00000000000000000000000001');
+
+      const body = JSON.parse(mockAdapter.history.post[0]!.data);
+      expect(body).toEqual({
+        traits: { Contact: { phone: '+13175551234' } },
+      });
+    });
+
+    it('should throw when response body has no id field', async () => {
+      mockAdapter
+        .onPost('/v1/Stores/mem_service_01kbjqhhdpft0tbp21jt4ktbxg/Profiles')
+        .reply(202, { foo: 'bar' });
+
+      await expect(
+        memoryClient.createProfile('mem_service_01kbjqhhdpft0tbp21jt4ktbxg', {
+          Contact: { phone: '+13175551234' },
+        })
+      ).rejects.toThrow(/CreateProfile response missing 'id' field/);
+    });
+
+    it('should surface HTTP errors', async () => {
+      mockAdapter
+        .onPost('/v1/Stores/mem_service_01kbjqhhdpft0tbp21jt4ktbxg/Profiles')
+        .reply(500);
+
+      await expect(
+        memoryClient.createProfile('mem_service_01kbjqhhdpft0tbp21jt4ktbxg', {
+          Contact: { phone: '+13175551234' },
+        })
+      ).rejects.toThrow(/Failed to create profile/);
+    });
+  });
+
   describe('region support', () => {
     it('should use region in base URL when configured', () => {
       const config = new TACConfig({ ...getTestConfig(), region: 'test-region' });

--- a/tests/outbound.test.ts
+++ b/tests/outbound.test.ts
@@ -147,27 +147,18 @@ describe('Outbound Conversations', () => {
       ).rejects.toThrow();
     });
 
-    it('should use custom from number when provided', async () => {
-      mockSmsOutbound(mockAdapter, 'CHfrom123', { fromAddress: '+15550009999' });
-
-      const result = await channel.initiateOutboundConversation({
-        to: '+15559876543',
-        from: '+15550009999',
-        message: 'Hello from a different number',
-      });
-
-      expect(result.session.metadata?.fromAddress).toBe('+15550009999');
-    });
-
-    it('should store default fromAddress in session metadata', async () => {
-      mockSmsOutbound(mockAdapter, 'CHdefault123');
+    it('should stash aiAgentInfo on the session after outbound initiation', async () => {
+      // The outbound path now populates session.aiAgentInfo alongside
+      // authorInfo so subsequent sendResponse calls can skip reconcile.
+      mockSmsOutbound(mockAdapter, 'CHoutbound_aiinfo', { agentParticipantId: 'PAagent_ai' });
 
       const result = await channel.initiateOutboundConversation({
         to: '+15559876543',
         message: 'Hello',
       });
 
-      expect(result.session.metadata?.fromAddress).toBe('+15551234567');
+      expect(result.session.aiAgentInfo?.address).toBe('+15551234567');
+      expect(result.session.aiAgentInfo?.participantId).toBe('PAagent_ai');
     });
 
     it('should validate options', async () => {
@@ -368,71 +359,6 @@ describe('Outbound Conversations', () => {
       });
     });
 
-    it('should use fromAddress from session metadata for agent participant lookup', async () => {
-      // Set up mocks for initiateOutboundConversation with custom from
-      mockAdapter.onPost(/\/v2\/Conversations$/).reply(200, {
-        id: 'CHsr002',
-        accountId: 'ACtest123456789',
-        status: 'ACTIVE',
-      });
-
-      mockAdapter.onGet(/\/CHsr002\/Participants$/).reply(200, {
-        participants: [
-          {
-            id: 'PAsr_cust2',
-            conversationId: 'CHsr002',
-            accountId: 'ACtest123456789',
-            type: 'CUSTOMER',
-            addresses: [{ channel: 'SMS', address: '+15559876543' }],
-          },
-          {
-            id: 'PAsr_agent2',
-            conversationId: 'CHsr002',
-            accountId: 'ACtest123456789',
-            type: 'AI_AGENT',
-            addresses: [{ channel: 'SMS', address: '+15550009999' }],
-          },
-        ],
-      });
-
-      mockAdapter.onPost(/\/CHsr002\/Actions$/).replyOnce(202, {
-        id: 'ACTsr_init2',
-        type: 'SEND_MESSAGE',
-        status: 'PENDING',
-        conversationId: 'CHsr002',
-        createdAt: '2024-01-01T00:00:00Z',
-      });
-
-      await channel.initiateOutboundConversation({
-        to: '+15559876543',
-        from: '+15550009999',
-        message: 'First message with custom from',
-      });
-
-      let capturedBody: unknown;
-      mockAdapter.onPost(/\/CHsr002\/Actions$/).reply(config => {
-        capturedBody = typeof config.data === 'string' ? JSON.parse(config.data) : config.data;
-        return [202, {
-          id: 'ACTsr_reply2',
-          type: 'SEND_MESSAGE',
-          status: 'PENDING',
-          conversationId: 'CHsr002',
-          createdAt: '2024-01-01T00:00:00Z',
-        }];
-      });
-
-      await channel.sendResponse('CHsr002', 'Reply using custom from');
-
-      // The agent participant should be resolved by the custom fromAddress (+15550009999)
-      expect(capturedBody).toMatchObject({
-        type: 'SEND_MESSAGE',
-        payload: {
-          from: { channel: 'SMS', participantId: 'PAsr_agent2' },
-          to: [{ channel: 'SMS', participantId: 'PAsr_cust2' }],
-          content: { text: 'Reply using custom from' },
-        },
-      });
-    });
   });
 
   describe('ChatChannel.initiateOutboundConversation', () => {
@@ -496,50 +422,6 @@ describe('Outbound Conversations', () => {
       expect(result.session.channel).toBe('chat');
       expect(result.session.metadata?.direction).toBe('outbound');
       expect(result.session.metadata?.channelId).toBe('CHSIDabc');
-    });
-
-    it('should use custom from address when provided', async () => {
-      mockAdapter.onPost(/\/v2\/Conversations$/).reply(200, {
-        id: 'CHchatfrom1',
-        accountId: 'ACtest123456789',
-        status: 'ACTIVE',
-      });
-
-      mockAdapter.onGet(/\/Participants$/).reply(200, {
-        participants: [
-          {
-            id: 'PAchatcust2',
-            conversationId: 'CHchatfrom1',
-            accountId: 'ACtest123456789',
-            type: 'CUSTOMER',
-            addresses: [{ channel: 'CHAT', address: 'customer@example.com', channelId: 'CHSIDabc' }],
-          },
-          {
-            id: 'PAchatagent2',
-            conversationId: 'CHchatfrom1',
-            accountId: 'ACtest123456789',
-            type: 'AI_AGENT',
-            addresses: [{ channel: 'CHAT', address: 'custom-agent@example.com', channelId: 'CHSIDabc' }],
-          },
-        ],
-      });
-
-      mockAdapter.onPost(/\/Actions$/).reply(202, {
-        id: 'ACTchat2',
-        type: 'SEND_MESSAGE',
-        status: 'PENDING',
-        conversationId: 'CHchatfrom1',
-        createdAt: '2024-01-01T00:00:00Z',
-      });
-
-      const result = await channel.initiateOutboundConversation({
-        to: 'customer@example.com',
-        from: 'custom-agent@example.com',
-        channelId: 'CHSIDabc',
-        message: 'Hello from custom agent',
-      });
-
-      expect(result.session.metadata?.fromAddress).toBe('custom-agent@example.com');
     });
 
     it('should reuse existing conversation on 409 (group-by dedup)', async () => {
@@ -811,24 +693,6 @@ describe('Outbound Conversations', () => {
           conversationRelayConfig: { url: 'wss://example.com/ws' },
         })
       ).rejects.toThrow('Call placement failed');
-    });
-
-    it('should use custom from number when provided', async () => {
-      mockCallCreate.mockResolvedValue({ sid: 'CA456outbound' });
-
-      await channel.initiateOutboundConversation({
-        to: '+15559876543',
-        from: '+15550001111',
-        conversationRelayConfig: {
-          url: 'wss://example.com/ws',
-        },
-      });
-
-      expect(mockCallCreate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          from: '+15550001111',
-        })
-      );
     });
 
     it('should validate required options', async () => {

--- a/tests/pii.test.ts
+++ b/tests/pii.test.ts
@@ -384,6 +384,25 @@ describe('PII masking', () => {
     it('should mask author in handle_message_ready logs', async () => {
       const loggerDebugSpy = vi.spyOn(tac.logger, 'debug');
 
+      // Short-circuit reconcile so the webhook reaches handle_message_ready.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      vi.spyOn(channel as any, 'reconcileParticipants').mockResolvedValue([
+        {
+          id: 'PA_AGENT',
+          accountId: 'ACtest123456789',
+          conversationId: 'CHtest_hmr',
+          type: 'AI_AGENT',
+          addresses: [{ channel: 'SMS', address: '+15551234567' }],
+        },
+        {
+          id: 'PA_CUSTOMER',
+          accountId: 'ACtest123456789',
+          conversationId: 'CHtest_hmr',
+          type: 'CUSTOMER',
+          addresses: [{ channel: 'SMS', address: '+15559876543' }],
+        },
+      ]);
+
       tac.onMessageReady(async () => {});
 
       await channel.processWebhook({

--- a/tests/reconciliation.test.ts
+++ b/tests/reconciliation.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SMSChannel, TAC } from '@twilio/tac-core';
+import type { ConversationParticipant } from '@twilio/tac-core';
+import MockAdapter from 'axios-mock-adapter';
+import axios, { AxiosError } from 'axios';
+import { createTestTAC } from './helpers/tac';
+
+/**
+ * Tests for `reconcileParticipants` in MessagingChannel.
+ *
+ * Covers the matrix of participant states that v1-bridge capture can leave us
+ * with. The resolution rules were agreed with the Maestro team.
+ */
+describe('Reconcile participants', () => {
+  const getTestConfig = () => ({
+    accountSid: 'ACtest',
+    authToken: 't',
+    apiKey: 'SK',
+    apiSecret: 's',
+    phoneNumber: '+15551234567',
+    conversationConfigurationId: 'conv_configuration_01kbjqhn79f0fvwfsxqzd5nqhd',
+  });
+
+  const AGENT_ADDR = '+15551234567';
+  const CUSTOMER_ADDR = '+12345678901';
+  const CONV_ID = 'CHtest123456789';
+
+  const participant = (
+    id: string,
+    type: string,
+    address: string,
+    channel: 'SMS' | 'CHAT' = 'SMS'
+  ): ConversationParticipant => ({
+    id,
+    accountId: 'ACtest',
+    conversationId: CONV_ID,
+    name: address,
+    type: type as ConversationParticipant['type'],
+    addresses: [{ channel, address }],
+  });
+
+  let tac: TAC;
+  let channel: SMSChannel;
+  let mockAdapter: MockAdapter;
+  // Stub memory profile calls by default — reconciliation tests should not hit
+  // Memora. Individual tests can override.
+  let stubLookupProfile: ReturnType<typeof vi.fn>;
+  let stubCreateProfile: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    tac = await createTestTAC(getTestConfig());
+    channel = new SMSChannel(tac);
+    mockAdapter = new MockAdapter(
+      (tac.getConversationClient() as unknown as { axiosInstance: typeof axios })
+        .axiosInstance
+    );
+
+    const memoryClient = tac.getMemoryClient() as unknown as {
+      lookupProfile: unknown;
+      createProfile: unknown;
+    };
+    stubLookupProfile = vi.fn().mockRejectedValue(new Error('lookup_profile not stubbed'));
+    stubCreateProfile = vi.fn().mockRejectedValue(new Error('create_profile not stubbed'));
+    memoryClient.lookupProfile = stubLookupProfile;
+    memoryClient.createProfile = stubCreateProfile;
+  });
+
+  afterEach(() => {
+    mockAdapter?.restore();
+    vi.restoreAllMocks();
+  });
+
+  const callReconcile = async (): Promise<
+    [ConversationParticipant, ConversationParticipant | null] | null
+  > =>
+    await (
+      channel as unknown as {
+        reconcileParticipants: (
+          id: string
+        ) => Promise<[ConversationParticipant, ConversationParticipant | null] | null>;
+      }
+    ).reconcileParticipants(CONV_ID);
+
+  const mockListParticipants = (participants: ConversationParticipant[]) =>
+    mockAdapter
+      .onGet(`/v2/Conversations/${CONV_ID}/Participants`)
+      .reply(200, { participants });
+
+  it('happy path: both sides correctly typed → no PUTs', async () => {
+    const agent = participant('PA_A', 'AI_AGENT', AGENT_ADDR);
+    const customer = participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR);
+    mockListParticipants([agent, customer]);
+
+    const result = await callReconcile();
+
+    expect(result).not.toBeNull();
+    expect(result![0].id).toBe('PA_A');
+    expect(result![1]).not.toBeNull();
+    expect(result![1]!.id).toBe('PA_C');
+    // No PUTs or POSTs issued.
+    expect(mockAdapter.history.put.length).toBe(0);
+    expect(mockAdapter.history.post.length).toBe(0);
+  });
+
+  it('agent good, customer UNKNOWN → promotes customer to CUSTOMER', async () => {
+    const agent = participant('PA_A', 'AI_AGENT', AGENT_ADDR);
+    const customerUnknown = participant('PA_C', 'UNKNOWN', CUSTOMER_ADDR);
+    const promoted = participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR);
+
+    mockListParticipants([agent, customerUnknown]);
+    mockAdapter
+      .onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_C`)
+      .reply(200, promoted);
+    // Stub lookup to miss, create to return an id.
+    stubLookupProfile.mockResolvedValue({ normalizedValue: CUSTOMER_ADDR, profiles: [] });
+    stubCreateProfile.mockResolvedValue('mem_profile_01new');
+
+    const result = await callReconcile();
+
+    expect(result).not.toBeNull();
+    expect(result![0].id).toBe('PA_A');
+    expect(result![1]).not.toBeNull();
+    expect(result![1]!.id).toBe('PA_C');
+    expect(result![1]!.type).toBe('CUSTOMER');
+    expect(mockAdapter.history.put.length).toBe(1);
+    const putBody = JSON.parse(mockAdapter.history.put[0]!.data);
+    expect(putBody.type).toBe('CUSTOMER');
+    expect(putBody.profileId).toBe('mem_profile_01new');
+  });
+
+  it('agent UNKNOWN, customer CUSTOMER → promotes agent to AI_AGENT', async () => {
+    const agentUnknown = participant('PA_A', 'UNKNOWN', AGENT_ADDR);
+    const customer = participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR);
+    const promoted = participant('PA_A', 'AI_AGENT', AGENT_ADDR);
+
+    mockListParticipants([agentUnknown, customer]);
+    mockAdapter
+      .onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_A`)
+      .reply(200, promoted);
+
+    const result = await callReconcile();
+
+    expect(result).not.toBeNull();
+    expect(result![0].id).toBe('PA_A');
+    expect(result![0].type).toBe('AI_AGENT');
+    expect(result![1]!.id).toBe('PA_C');
+    expect(mockAdapter.history.put.length).toBe(1);
+    const putBody = JSON.parse(mockAdapter.history.put[0]!.data);
+    expect(putBody.type).toBe('AI_AGENT');
+  });
+
+  it('both sides UNKNOWN → two PUTs', async () => {
+    const agentUnknown = participant('PA_A', 'UNKNOWN', AGENT_ADDR);
+    const customerUnknown = participant('PA_C', 'UNKNOWN', CUSTOMER_ADDR);
+    const promotedAgent = participant('PA_A', 'AI_AGENT', AGENT_ADDR);
+    const promotedCustomer = participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR);
+
+    mockListParticipants([agentUnknown, customerUnknown]);
+    mockAdapter
+      .onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_A`)
+      .reply(200, promotedAgent);
+    mockAdapter
+      .onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_C`)
+      .reply(200, promotedCustomer);
+    stubLookupProfile.mockResolvedValue({ normalizedValue: CUSTOMER_ADDR, profiles: [] });
+    stubCreateProfile.mockResolvedValue('mem_profile_01new');
+
+    const result = await callReconcile();
+
+    expect(result).not.toBeNull();
+    expect(result![0].type).toBe('AI_AGENT');
+    expect(result![1]!.type).toBe('CUSTOMER');
+    expect(mockAdapter.history.put.length).toBe(2);
+  });
+
+  it.each(['HUMAN_AGENT', 'CUSTOMER'])(
+    "non-agent type '%s' at our address refuses to overwrite",
+    async conflictingType => {
+      // HUMAN_AGENT / CUSTOMER owning TAC's (channel, address) is someone
+      // else's assignment — refuse and bail.
+      const conflicting = participant('PA_A', conflictingType, AGENT_ADDR);
+      const customer = participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR);
+      mockListParticipants([conflicting, customer]);
+
+      const result = await callReconcile();
+
+      expect(result).toBeNull();
+      expect(mockAdapter.history.put.length).toBe(0);
+      expect(mockAdapter.history.post.length).toBe(0);
+    }
+  );
+
+  it('solo customer → POST AI_AGENT, then use', async () => {
+    const customer = participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR);
+    const createdAgent = participant('PA_A', 'AI_AGENT', AGENT_ADDR);
+    mockListParticipants([customer]);
+    mockAdapter
+      .onPost(`/v2/Conversations/${CONV_ID}/Participants`)
+      .reply(201, createdAgent);
+
+    const result = await callReconcile();
+
+    expect(result).not.toBeNull();
+    expect(result![0].id).toBe('PA_A');
+    expect(result![0].type).toBe('AI_AGENT');
+    expect(result![1]!.id).toBe('PA_C');
+    expect(mockAdapter.history.post.length).toBe(1);
+    const postBody = JSON.parse(mockAdapter.history.post[0]!.data);
+    expect(postBody.type).toBe('AI_AGENT');
+    expect(postBody.addresses[0].address).toBe(AGENT_ADDR);
+  });
+
+  it('POST AI_AGENT returns 409 → null (Maestro structural conflict)', async () => {
+    // A 409 here signals something structural (duplicate conversation,
+    // address already owned, grouping constraint) that TAC can't safely
+    // paper over by retrying.
+    const customer = participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR);
+    mockListParticipants([customer]);
+    mockAdapter
+      .onPost(`/v2/Conversations/${CONV_ID}/Participants`)
+      .reply(409, { message: 'already owned' });
+
+    const result = await callReconcile();
+
+    expect(result).toBeNull();
+  });
+
+  it('PUT promotion returns 409 → null', async () => {
+    const agentUnknown = participant('PA_A', 'UNKNOWN', AGENT_ADDR);
+    const customer = participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR);
+    mockListParticipants([agentUnknown, customer]);
+    mockAdapter
+      .onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_A`)
+      .reply(409, { message: 'conflict' });
+
+    const result = await callReconcile();
+
+    expect(result).toBeNull();
+  });
+
+  it('listParticipants failure → null (skips the webhook)', async () => {
+    mockAdapter
+      .onGet(`/v2/Conversations/${CONV_ID}/Participants`)
+      .networkError();
+
+    const result = await callReconcile();
+
+    expect(result).toBeNull();
+    expect(mockAdapter.history.put.length).toBe(0);
+  });
+
+  it('customer promotion: lookup miss creates a profile with configured trait group/field', async () => {
+    const agent = participant('PA_A', 'AI_AGENT', AGENT_ADDR);
+    const customerUnknown = participant('PA_C', 'UNKNOWN', CUSTOMER_ADDR);
+    const promoted = participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR);
+
+    mockListParticipants([agent, customerUnknown]);
+    mockAdapter
+      .onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_C`)
+      .reply(200, promoted);
+
+    stubLookupProfile.mockResolvedValue({ normalizedValue: CUSTOMER_ADDR, profiles: [] });
+    stubCreateProfile.mockResolvedValue('mem_profile_01new');
+
+    const result = await callReconcile();
+
+    expect(result).not.toBeNull();
+    expect(stubLookupProfile).toHaveBeenCalledTimes(1);
+    expect(stubCreateProfile).toHaveBeenCalledTimes(1);
+    expect(stubCreateProfile).toHaveBeenCalledWith(
+      expect.any(String),
+      { Contact: { phone: CUSTOMER_ADDR } }
+    );
+    const putBody = JSON.parse(mockAdapter.history.put[0]!.data);
+    expect(putBody.profileId).toBe('mem_profile_01new');
+  });
+
+  it('customer promotion proceeds without profile when lookup and create both fail', async () => {
+    const agent = participant('PA_A', 'AI_AGENT', AGENT_ADDR);
+    const customerUnknown = participant('PA_C', 'UNKNOWN', CUSTOMER_ADDR);
+    const promoted = participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR);
+
+    mockListParticipants([agent, customerUnknown]);
+    mockAdapter
+      .onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_C`)
+      .reply(200, promoted);
+
+    // Both lookup and create fail — reconciliation still promotes, just
+    // without a profileId attached.
+    const networkErr = new AxiosError('memora down');
+    stubLookupProfile.mockRejectedValue(networkErr);
+    stubCreateProfile.mockRejectedValue(networkErr);
+
+    const result = await callReconcile();
+
+    expect(result).not.toBeNull();
+    const putBody = JSON.parse(mockAdapter.history.put[0]!.data);
+    expect(putBody.type).toBe('CUSTOMER');
+    expect(putBody.profileId).toBeUndefined();
+  });
+
+  it('reconciliation lifts customer profileId onto session.profileId', async () => {
+    // When reconcile resolves a CUSTOMER that already has a profile_id
+    // (set by a prior reconciliation / Memora identity-resolution), the
+    // handler should copy it onto session.profileId so retrieve_memory's
+    // fallback path doesn't redo the lookup.
+    const agent = participant('PA_A', 'AI_AGENT', AGENT_ADDR);
+    const customerWithProfile: ConversationParticipant = {
+      ...participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR),
+      profileId: 'mem_profile_01abc',
+    };
+    mockListParticipants([agent, customerWithProfile]);
+
+    const webhookEvent = {
+      eventType: 'COMMUNICATION_CREATED',
+      data: {
+        id: 'comms_communication_01test',
+        conversationId: CONV_ID,
+        content: { type: 'TEXT', text: 'hi' },
+        author: {
+          address: CUSTOMER_ADDR,
+          channel: 'SMS',
+          participantId: 'PA_C',
+        },
+      },
+    };
+
+    // Short-circuit memory retrieval so we focus on the profileId lift.
+    vi.spyOn(tac, 'retrieveMemory').mockResolvedValue(undefined as never);
+
+    await channel.processWebhook(webhookEvent);
+
+    const session = (
+      channel as unknown as { activeConversations: Map<string, { profileId?: string }> }
+    ).activeConversations.get(CONV_ID);
+    expect(session).toBeDefined();
+    expect(session!.profileId).toBe('mem_profile_01abc');
+  });
+});

--- a/tests/reconciliation.test.ts
+++ b/tests/reconciliation.test.ts
@@ -267,10 +267,9 @@ describe('Reconcile participants', () => {
     expect(result).not.toBeNull();
     expect(stubLookupProfile).toHaveBeenCalledTimes(1);
     expect(stubCreateProfile).toHaveBeenCalledTimes(1);
-    expect(stubCreateProfile).toHaveBeenCalledWith(
-      expect.any(String),
-      { Contact: { phone: CUSTOMER_ADDR } }
-    );
+    expect(stubCreateProfile).toHaveBeenCalledWith({
+      Contact: { phone: CUSTOMER_ADDR },
+    });
     const putBody = JSON.parse(mockAdapter.history.put[0]!.data);
     expect(putBody.profileId).toBe('mem_profile_01new');
   });

--- a/tests/reconciliation.test.ts
+++ b/tests/reconciliation.test.ts
@@ -300,9 +300,9 @@ describe('Reconcile participants', () => {
   });
 
   it('reconciliation lifts customer profileId onto session.profileId', async () => {
-    // When reconcile resolves a CUSTOMER that already has a profile_id
+    // When reconcile resolves a CUSTOMER that already has a profileId
     // (set by a prior reconciliation / Memora identity-resolution), the
-    // handler should copy it onto session.profileId so retrieve_memory's
+    // handler should copy it onto session.profileId so retrieveMemory's
     // fallback path doesn't redo the lookup.
     const agent = participant('PA_A', 'AI_AGENT', AGENT_ADDR);
     const customerWithProfile: ConversationParticipant = {

--- a/tests/reconciliation.test.ts
+++ b/tests/reconciliation.test.ts
@@ -9,7 +9,7 @@ import { createTestTAC } from './helpers/tac';
  * Tests for `reconcileParticipants` in MessagingChannel.
  *
  * Covers the matrix of participant states that v1-bridge capture can leave us
- * with. The resolution rules were agreed with the Maestro team.
+ * with. The resolution rules were agreed with the Conversation Orchestrator team.
  */
 describe('Reconcile participants', () => {
   const getTestConfig = () => ({
@@ -43,7 +43,7 @@ describe('Reconcile participants', () => {
   let channel: SMSChannel;
   let mockAdapter: MockAdapter;
   // Stub memory profile calls by default — reconciliation tests should not hit
-  // Memora. Individual tests can override.
+  // Conversation Memory. Individual tests can override.
   let stubLookupProfile: ReturnType<typeof vi.fn>;
   let stubCreateProfile: ReturnType<typeof vi.fn>;
 
@@ -210,7 +210,7 @@ describe('Reconcile participants', () => {
     expect(postBody.addresses[0].address).toBe(AGENT_ADDR);
   });
 
-  it('POST AI_AGENT returns 409 → null (Maestro structural conflict)', async () => {
+  it('POST AI_AGENT returns 409 → null (Conversation Orchestrator structural conflict)', async () => {
     // A 409 here signals something structural (duplicate conversation,
     // address already owned, grouping constraint) that TAC can't safely
     // paper over by retrying.
@@ -286,7 +286,7 @@ describe('Reconcile participants', () => {
 
     // Both lookup and create fail — reconciliation still promotes, just
     // without a profileId attached.
-    const networkErr = new AxiosError('memora down');
+    const networkErr = new AxiosError('conversation memory down');
     stubLookupProfile.mockRejectedValue(networkErr);
     stubCreateProfile.mockRejectedValue(networkErr);
 
@@ -300,7 +300,7 @@ describe('Reconcile participants', () => {
 
   it('reconciliation lifts customer profileId onto session.profileId', async () => {
     // When reconcile resolves a CUSTOMER that already has a profileId
-    // (set by a prior reconciliation / Memora identity-resolution), the
+    // (set by a prior reconciliation / Conversation Memory identity-resolution), the
     // handler should copy it onto session.profileId so retrieveMemory's
     // fallback path doesn't redo the lookup.
     const agent = participant('PA_A', 'AI_AGENT', AGENT_ADDR);

--- a/tests/sms-channel.test.ts
+++ b/tests/sms-channel.test.ts
@@ -29,6 +29,25 @@ describe('SMS Channel', () => {
     // Short-circuit memory retrieval so webhook processing tests don't hit
     // real Twilio APIs with fake credentials and spam the logs with 401s.
     vi.spyOn(tac, 'retrieveMemory').mockResolvedValue(undefined as never);
+    // Short-circuit reconcileParticipants so webhook processing tests don't
+    // need to mock listParticipants. Tests that care about reconcile behavior
+    // should override this spy.
+    vi.spyOn(channel as any, 'reconcileParticipants').mockResolvedValue([
+      {
+        id: 'PA111',
+        conversationId: 'CHtest123456789',
+        accountId: 'ACtest123456789',
+        type: 'AI_AGENT',
+        addresses: [{ channel: 'SMS', address: '+15551234567' }],
+      },
+      {
+        id: 'PA222',
+        conversationId: 'CHtest123456789',
+        accountId: 'ACtest123456789',
+        type: 'CUSTOMER',
+        addresses: [{ channel: 'SMS', address: '+15559876543' }],
+      },
+    ]);
   });
 
   describe('initialization', () => {
@@ -403,6 +422,23 @@ describe('SMS Channel', () => {
 
     it('should evict oldest tokens when capacity is reached', async () => {
       const smallChannel = new SMSChannel(tac, { dedupCapacity: 2 });
+      // Short-circuit reconcile on the extra channel so the callback fires.
+      vi.spyOn(smallChannel as any, 'reconcileParticipants').mockResolvedValue([
+        {
+          id: 'PA111',
+          conversationId: 'CHtest123456789',
+          accountId: 'ACtest123456789',
+          type: 'AI_AGENT',
+          addresses: [{ channel: 'SMS', address: '+15551234567' }],
+        },
+        {
+          id: 'PA222',
+          conversationId: 'CHtest123456789',
+          accountId: 'ACtest123456789',
+          type: 'CUSTOMER',
+          addresses: [{ channel: 'SMS', address: '+15559876543' }],
+        },
+      ]);
       const callback = vi.fn();
       smallChannel.on('messageReceived', callback);
 
@@ -484,6 +520,32 @@ describe('SMS Channel', () => {
   });
 
   describe('sendResponse', () => {
+    /**
+     * Pre-populate a fully-reconciled session. `sendResponse` now reads ids
+     * directly from `session.authorInfo` and `session.aiAgentInfo`; it no
+     * longer calls `listParticipants`/`addParticipant` at send time.
+     */
+    const seedReconciledSession = (conversationId: string, opts?: {
+      channelId?: string;
+      agentParticipantId?: string;
+      customerParticipantId?: string;
+    }) => {
+      (channel as any).activeConversations.set(conversationId, {
+        conversationId,
+        channel: 'sms',
+        startedAt: new Date(),
+        authorInfo: {
+          address: '+15559876543',
+          participantId: opts?.customerParticipantId ?? 'PA123',
+        },
+        aiAgentInfo: {
+          address: '+15551234567',
+          participantId: opts?.agentParticipantId ?? 'PA111',
+        },
+        metadata: opts?.channelId ? { channelId: opts.channelId } : {},
+      });
+    };
+
     beforeEach(() => {
       // Access the conversation client's axios instance through TAC
       const conversationClient = (tac as any).conversationClient;
@@ -491,27 +553,8 @@ describe('SMS Channel', () => {
       // Reset history to clear the getConfiguration call from TAC initialization
       mockAdapter.resetHistory();
 
-      // Mock listParticipants call
-      mockAdapter.onGet('/v2/Conversations/CHtest123456789/Participants').reply(200, {
-        participants: [
-          {
-            id: 'PA111',
-            conversationId: 'CHtest123456789',
-            accountId: 'ACtest123456789',
-            type: 'AI_AGENT',
-            addresses: [{ channel: 'SMS', address: '+15551234567' }],
-          },
-          {
-            id: 'PA123',
-            conversationId: 'CHtest123456789',
-            accountId: 'ACtest123456789',
-            type: 'CUSTOMER',
-            addresses: [{ channel: 'SMS', address: '+15559876543' }],
-          },
-        ],
-      });
-
-      // Mock createAction call (returns 202 Accepted)
+      // Mock createAction call (returns 202 Accepted). sendResponse no longer
+      // calls listParticipants — the session is pre-reconciled.
       mockAdapter.onPost('/v2/Conversations/CHtest123456789/Actions').reply(202, {
         id: 'conv_action_01abcdef',
         type: 'SEND_MESSAGE',
@@ -522,36 +565,13 @@ describe('SMS Channel', () => {
     });
 
     it('should send SMS via Actions API', async () => {
-      // Start conversation and receive message to populate author_info
-      await channel.processWebhook({
-        eventType: 'CONVERSATION_CREATED',
-        data: {
-          conversationId: 'CHtest123456789',
-        },
-      });
-
-      await channel.processWebhook({
-        eventType: 'COMMUNICATION_CREATED',
-        data: {
-          conversationId: 'CHtest123456789',
-          content: {
-            type: 'TEXT',
-            text: 'Hello',
-          },
-          author: {
-            address: '+15559876543',
-            channel: 'SMS',
-            participantId: 'PA123',
-          },
-        },
-      });
+      seedReconciledSession('CHtest123456789');
 
       await channel.sendResponse('CHtest123456789', 'Hello back!');
 
-      // Verify that the correct requests were made (listParticipants + createAction)
+      // sendResponse no longer calls listParticipants — only createAction
       const history = mockAdapter.history;
-      expect(history.get.length).toBe(1); // listParticipants
-      expect(history.get[0]!.url).toBe('/v2/Conversations/CHtest123456789/Participants');
+      expect(history.get.length).toBe(0);
 
       expect(history.post.length).toBe(1);
       expect(history.post[0]!.url).toBe('/v2/Conversations/CHtest123456789/Actions');
@@ -568,26 +588,12 @@ describe('SMS Channel', () => {
       expect(body.payload.to[0]).not.toHaveProperty('address');
       expect(body.payload.content.text).toBe('Hello back!');
       expect(body.payload.content).not.toHaveProperty('type'); // Actions content has no discriminator
-      // No channelId on the webhook → channelSettings omitted
+      // No channelId in session → channelSettings omitted
       expect(body.payload).not.toHaveProperty('channelSettings');
     });
 
     it('should forward channelId as channelSettings.channelId when present', async () => {
-      await channel.processWebhook({
-        eventType: 'CONVERSATION_CREATED',
-        data: { conversationId: 'CHtest123456789' },
-      });
-
-      // Inbound communication carrying a channelId (stored in session.metadata)
-      await channel.processWebhook({
-        eventType: 'COMMUNICATION_CREATED',
-        data: {
-          conversationId: 'CHtest123456789',
-          content: { type: 'TEXT', text: 'Hello' },
-          author: { address: '+15559876543', channel: 'SMS', participantId: 'PA123' },
-          channelId: 'SMabcdef',
-        },
-      });
+      seedReconciledSession('CHtest123456789', { channelId: 'SMabcdef' });
 
       await channel.sendResponse('CHtest123456789', 'Reply');
 
@@ -595,153 +601,37 @@ describe('SMS Channel', () => {
       expect(body.payload.channelSettings.channelId).toBe('SMabcdef');
     });
 
-    it('should lazily create AI_AGENT participant when absent', async () => {
-      // Replace the default listParticipants mock with one that returns only the customer
-      mockAdapter.reset();
-      // keep the getConfiguration call silent (already resolved in createTestTAC)
-      mockAdapter.onGet('/v2/Conversations/CHtest123456789/Participants').reply(200, {
-        participants: [
-          {
-            id: 'PA123',
-            conversationId: 'CHtest123456789',
-            accountId: 'ACtest123456789',
-            type: 'CUSTOMER',
-            addresses: [{ channel: 'SMS', address: '+15559876543' }],
-          },
-        ],
-      });
-      mockAdapter.onPost('/v2/Conversations/CHtest123456789/Participants').reply(201, {
-        id: 'PA_NEW_AGENT',
-        conversationId: 'CHtest123456789',
-        accountId: 'ACtest123456789',
-        type: 'AI_AGENT',
-        addresses: [{ channel: 'SMS', address: '+15551234567' }],
-      });
-      mockAdapter.onPost('/v2/Conversations/CHtest123456789/Actions').reply(202, {
-        id: 'conv_action_01abcdef',
-        type: 'SEND_MESSAGE',
-        status: 'PENDING',
-        conversationId: 'CHtest123456789',
-      });
-
-      await channel.processWebhook({
-        eventType: 'CONVERSATION_CREATED',
-        data: { conversationId: 'CHtest123456789' },
-      });
-      await channel.processWebhook({
-        eventType: 'COMMUNICATION_CREATED',
-        data: {
-          conversationId: 'CHtest123456789',
-          content: { type: 'TEXT', text: 'Hello' },
-          author: { address: '+15559876543', channel: 'SMS', participantId: 'PA123' },
-        },
-      });
-
-      await channel.sendResponse('CHtest123456789', 'Reply');
-
-      const posts = mockAdapter.history.post;
-      expect(posts).toHaveLength(2); // addParticipant + createAction
-
-      const addParticipantCall = posts.find(p =>
-        p.url?.endsWith('/Participants')
-      );
-      expect(addParticipantCall).toBeDefined();
-      const addBody = JSON.parse(addParticipantCall!.data);
-      expect(addBody.type).toBe('AI_AGENT');
-      expect(addBody.addresses).toHaveLength(1);
-      expect(addBody.addresses[0].channel).toBe('SMS');
-      expect(addBody.addresses[0].address).toBe('+15551234567');
-
-      const actionCall = posts.find(p => p.url?.endsWith('/Actions'));
-      expect(actionCall).toBeDefined();
-      const actionBody = JSON.parse(actionCall!.data);
-      expect(actionBody.payload.from.participantId).toBe('PA_NEW_AGENT');
-    });
-
-    it('should throw error when no session exists', async () => {
+    it('should throw when no session exists', async () => {
       await expect(channel.sendResponse('CHnonexistent', 'Test')).rejects.toThrow(
-        'No active session found'
+        'without a reconciled session'
       );
     });
 
-    it('should throw error when no author_info exists', async () => {
-      // Start conversation but don't receive any message
-      await channel.processWebhook({
-        eventType: 'CONVERSATION_CREATED',
-        data: {
-          conversationId: 'CHtest123456789',
-        },
+    it('should throw when session is missing authorInfo', async () => {
+      // Start conversation but don't populate authorInfo or aiAgentInfo
+      (channel as any).activeConversations.set('CHtest123456789', {
+        conversationId: 'CHtest123456789',
+        channel: 'sms',
+        startedAt: new Date(),
+        metadata: {},
       });
 
       await expect(channel.sendResponse('CHtest123456789', 'Test')).rejects.toThrow(
-        'No author info found'
+        'without a reconciled session'
       );
     });
 
-    it('should throw when ensureAgentParticipant fails', async () => {
-      mockAdapter.reset();
-      // Only customer in the participant list and addParticipant fails
-      mockAdapter.onGet('/v2/Conversations/CHtest123456789/Participants').reply(200, {
-        participants: [
-          {
-            id: 'PA123',
-            conversationId: 'CHtest123456789',
-            accountId: 'ACtest123456789',
-            type: 'CUSTOMER',
-            addresses: [{ channel: 'SMS', address: '+15559876543' }],
-          },
-        ],
-      });
-      mockAdapter.onPost('/v2/Conversations/CHtest123456789/Participants').reply(500);
-
-      await channel.processWebhook({
-        eventType: 'CONVERSATION_CREATED',
-        data: { conversationId: 'CHtest123456789' },
-      });
-      await channel.processWebhook({
-        eventType: 'COMMUNICATION_CREATED',
-        data: {
-          conversationId: 'CHtest123456789',
-          content: { type: 'TEXT', text: 'Hello' },
-          author: { address: '+15559876543', channel: 'SMS', participantId: 'PA123' },
-        },
+    it('should throw when session is missing aiAgentInfo', async () => {
+      (channel as any).activeConversations.set('CHtest123456789', {
+        conversationId: 'CHtest123456789',
+        channel: 'sms',
+        startedAt: new Date(),
+        authorInfo: { address: '+15559876543', participantId: 'PA123' },
+        metadata: {},
       });
 
       await expect(channel.sendResponse('CHtest123456789', 'Reply')).rejects.toThrow(
-        'Failed to resolve AI_AGENT participant'
-      );
-    });
-
-    it('should throw when no CUSTOMER participant is found on SMS', async () => {
-      mockAdapter.reset();
-      // Only the agent participant exists — no CUSTOMER
-      mockAdapter.onGet('/v2/Conversations/CHtest123456789/Participants').reply(200, {
-        participants: [
-          {
-            id: 'PA111',
-            conversationId: 'CHtest123456789',
-            accountId: 'ACtest123456789',
-            type: 'AI_AGENT',
-            addresses: [{ channel: 'SMS', address: '+15551234567' }],
-          },
-        ],
-      });
-
-      await channel.processWebhook({
-        eventType: 'CONVERSATION_CREATED',
-        data: { conversationId: 'CHtest123456789' },
-      });
-      await channel.processWebhook({
-        eventType: 'COMMUNICATION_CREATED',
-        data: {
-          conversationId: 'CHtest123456789',
-          content: { type: 'TEXT', text: 'Hello' },
-          author: { address: '+15559876543', channel: 'SMS', participantId: 'PA_other' },
-        },
-      });
-
-      await expect(channel.sendResponse('CHtest123456789', 'Reply')).rejects.toThrow(
-        'Customer participant not found'
+        'without a reconciled session'
       );
     });
   });

--- a/tests/tac.test.ts
+++ b/tests/tac.test.ts
@@ -134,6 +134,23 @@ describe('TAC Core', () => {
       tac.registerChannel(channel);
 
       vi.spyOn(tac, 'retrieveMemory').mockResolvedValue(undefined as any);
+      // Short-circuit reconcile so the message-ready callback fires.
+      vi.spyOn(channel as any, 'reconcileParticipants').mockResolvedValue([
+        {
+          id: 'PA111',
+          conversationId: 'CHtest',
+          accountId: 'ACtest123456789',
+          type: 'AI_AGENT',
+          addresses: [{ channel: 'SMS', address: '+15551234567' }],
+        },
+        {
+          id: 'PA222',
+          conversationId: 'CHtest',
+          accountId: 'ACtest123456789',
+          type: 'CUSTOMER',
+          addresses: [{ channel: 'SMS', address: '+15559876543' }],
+        },
+      ]);
       const sendSpy = vi.spyOn(channel, 'sendResponse').mockResolvedValue();
       const warnSpy = vi.spyOn(tac.logger, 'warn');
 


### PR DESCRIPTION
## Summary

Synced from Python SDK PR: https://github.com/twilio/twilio-agent-connect-python/pull/19

v1 Conversations bridge creates inbound SMS participants with type `UNKNOWN`. The old send path POSTed `AI_AGENT` at send time, got 409 ("address already owned"), and the retry rejected `UNKNOWN` — dropping agent replies after the LLM had already run.

### What changed

1. **Centralize participant resolution.** Move out of send-time into two well-defined places: pre-LLM on inbound (new `reconcileParticipants`), and at outbound initiation. `sendResponse` becomes a thin Actions wrapper that reads participant ids stashed on the session (throws if missing — fail fast).

2. **Reconcile types on inbound.** `reconcileParticipants` lists participants once, PUTs `UNKNOWN → AI_AGENT` at TAC's address (POSTs if absent), and — on phone-based channels — PUTs `UNKNOWN → CUSTOMER` with a Memora profile attached (lookup by phone, else `createProfile`). Chat skips customer promotion (`reconcileCustomerType = false`) because chat addresses are opaque and the webhook's `author.participantId` is already authoritative.

3. **Remove `from` override from outbound options** (SMS, Chat, Voice). Multi-sender fragments inbound webhook routing, memory scoping, and config — easier to run one TAC instance per sender.

4. **Remove `PARTICIPANT_ADDED` handling.** The handler only seeded `profileId`, which is now resolved lazily from the customer's address at memory-retrieval time.

5. **Simplify `isOwnMessage` to 2-tier** (default-agent-address + API fallback). Only `AGENT` and `AI_AGENT` are recognized as self at TAC's address — `HUMAN_AGENT` is a real human and their messages must reach the callback.

6. **409 is a hard stop** on `addParticipant` / `updateParticipant`. Log WARN with `X-Conflicting-Resource-Id` and skip the callback — don't retry.

### Reconcile decision matrix

`AGENT_TYPES = {AGENT, AI_AGENT}` is TAC. `HUMAN_AGENT` is explicitly NOT TAC (real human, separate participant — TAC must not speak on their behalf).

| Agent side             | Customer side           | Action                                |
|------------------------|-------------------------|---------------------------------------|
| AGENT / AI_AGENT       | CUSTOMER                | Use as-is (no profile work).          |
| AGENT / AI_AGENT       | UNKNOWN, no CUSTOMER    | Resolve profile, PUT → CUSTOMER.      |
| UNKNOWN at our addr    | CUSTOMER                | PUT agent → AI_AGENT.                 |
| UNKNOWN at our addr    | UNKNOWN, no CUSTOMER    | PUT agent; resolve, PUT CUSTOMER.     |
| other at our addr      | any                     | Return null (log ERROR, bail).        |
| none at our addr       | CUSTOMER or UNKNOWN     | POST AI_AGENT, then proceed.          |
| any                    | no resolvable customer  | Return null (log WARN, skip callback).|

### New API surface

- `ConversationClient.updateParticipant` — PUT for type promotion.
- `MemoryClient.createProfile(traits)` — mints a profile via identity resolution.
- `TwilioMemoryConfig.phoneTraitGroup` / `phoneTraitField` (env: `TWILIO_MEMORY_PHONE_TRAIT_GROUP` / `_FIELD`) — configurable to match the Memora store's identity-resolution schema.
- `ConversationSession.aiAgentInfo` — agent-side participant info stashed by reconciliation / outbound initiation.

## Manual testing

Validated end-to-end against live Maestro + Memora on a v1-bridge-enabled test account. Confirmed:
- v1-bridge inbound with fresh customer → POST AI_AGENT, PUT UNKNOWN→CUSTOMER with new profile
- Warm-turn short-circuit (turn 2+ skips reconcile via `aiAgentInfo` gate)
- Existing-profile lookup hit reuses canonical profileId
- Non-v1-bridge (pure v2 capture) happy path — no PUTs/POSTs since participants already correctly typed
- Outbound initiation stashes `aiAgentInfo`; `sendResponse` uses stashed ids without listing participants

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [x] Refactoring

## Checklist

- [x] Tests added/updated (467 tests pass, +12 new)
- [ ] Documentation updated
- [x] Tested E2E

## SDK Parity

- [ ] Change is TypeScript-specific (no Python update needed)
- [x] Python SDK PR created: https://github.com/twilio/twilio-agent-connect-python/pull/19

---

🤖 Generated by the `/sync-to-ts-sdk` skill.