### PR TITLE
feat(core): Add WhatsApp channel support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Twilio Agent Connect - TypeScript SDK
 
-A TypeScript framework for building AI-powered conversational agents on Twilio infrastructure. Provides channel abstractions (SMS, Voice), tool integration, memory/knowledge APIs, and a production-ready Fastify server — designed for 1:1 parity with the [Python SDK](https://github.com/twilio/twilio-agent-connect-python).
+A TypeScript framework for building AI-powered conversational agents on Twilio infrastructure. Provides channel abstractions (SMS, WhatsApp, Chat, Voice), tool integration, memory/knowledge APIs, and a production-ready Fastify server — designed for 1:1 parity with the [Python SDK](https://github.com/twilio/twilio-agent-connect-python).
 
 ## Development Commands
 
@@ -21,7 +21,7 @@ npm run typecheck      # tsc --noEmit
 
 ```
 packages/
-  core/        # Central framework: TAC orchestrator, channels (SMS/Voice),
+  core/        # Central framework: TAC orchestrator, channels (SMS/WhatsApp/Chat/Voice),
                #   API clients (Memory, Conversation, Knowledge), adapters
                #   (MemoryPromptBuilder), config, types
   tools/       # Tool system: TACTool class, defineTool(), built-in tools
@@ -46,7 +46,7 @@ getting_started/  # Example apps (OpenAI integration)
 ## Key Architecture
 
 - **TAC class** (`packages/core/src/lib/tac.ts`): Central orchestrator managing config, channels, callbacks, and API clients
-- **Channel abstraction** (`packages/core/src/channels/base.ts`): `BaseChannel` abstract base class extended by `SMSChannel` (webhooks/TwiML) and `VoiceChannel` (WebSocket)
+- **Channel abstraction** (`packages/core/src/channels/base.ts`): `BaseChannel` abstract base class extended by `MessagingChannel` (SMS/WhatsApp/Chat via webhooks) and `VoiceChannel` (WebSocket)
 - **Voice channel initialization**: In orchestrated mode, VoiceChannel waits for the first prompt message to initialize the conversation (polls Conversation Orchestrator using `callSid`, extracts `profileId` from participants, then starts local session). In voice-only mode (no `conversationConfigurationId`), uses `callSid` directly as the conversation ID without polling.
 - **Callback pattern**: Simple callbacks (`onMessageReady`, `onInterrupt`, `onConversationEnded`) instead of EventEmitter
 - **Callback responses**: `onMessageReady` callbacks return `string` (auto-sent), `void`/`null` (manual `channel.sendResponse()`)
@@ -121,6 +121,7 @@ Channels support `memoryMode` to control automatic memory fetching:
 
 ```typescript
 const smsChannel = new SMSChannel(tac, { memoryMode: 'always' });
+const whatsappChannel = new WhatsAppChannel(tac, { memoryMode: 'always' });
 const voiceChannel = new VoiceChannel(tac, { memoryMode: 'never' }); // default
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Seamlessly integrate with Twilio's Memory Store and Conversation Orchestrator to
 
 ## Key Features
 
-- **Messaging Channel Support**: Built-in webhook handling for SMS and Chat conversations
+- **Messaging Channel Support**: Built-in webhook handling for SMS, WhatsApp, and Chat conversations
 - **Voice Channel Support**: WebSocket protocol handling for Twilio Voice with ConversationRelay
-- **Outbound Conversations**: Agent-initiated conversations via SMS, Chat, and Voice channels
+- **Outbound Conversations**: Agent-initiated conversations via SMS, WhatsApp, Chat, and Voice channels
 - **ConversationRelay-Only Mode**: Get started quickly with TAC's voice plumbing (TwiML, WebSocket, callbacks) before adding Conversation Orchestrator
 - **Memory Management**: Automatic integration with Twilio Memory for persistent user context
 - **Conversation Lifecycle**: Automatic tracking of conversation sessions and state
@@ -193,6 +193,7 @@ For detailed architecture and advanced usage, see [CLAUDE.md](CLAUDE.md).
 **Examples & Guides:**
 - **[Getting Started Guide](getting_started/)** - Examples and comprehensive documentation
 - **[OpenAI SDK Example](getting_started/examples/openai/)** - Complete multi-channel example with Voice, SMS, and Chat
+- **[WhatsApp Example](getting_started/examples/features/whatsapp/)** - WhatsApp channel with memory integration
 - **[Chat Example](getting_started/examples/chat/)** - Web chat integration example
 - **[ConversationRelay-Only Mode](getting_started/examples/relay-only/)** - Get started with voice using just ConversationRelay
 - **[Outbound Conversations](getting_started/examples/outbound/)** - Agent-initiated conversations example

--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -83,6 +83,7 @@ See [`examples/.env.example`](examples/.env.example) for all available configura
 ### Optional (Server)
 
 - `TWILIO_VOICE_PUBLIC_DOMAIN`: Your ngrok domain without `https://` prefix (required for voice, e.g., `abc123.ngrok.app`)
+- `TWILIO_WHATSAPP_NUMBER`: Your Twilio WhatsApp number (required for WhatsApp channel, e.g., `whatsapp:+1234567890`)
 
 ### Optional (Handoff)
 
@@ -94,7 +95,9 @@ See [`examples/.env.example`](examples/.env.example) for all available configura
 
 ## Other Examples
 
+- **[WhatsApp Example](examples/features/whatsapp/)** - WhatsApp channel with memory integration
 - **[Chat Example](examples/chat/)** - Web-based chat using the Twilio Conversations JS SDK and ChatChannel
+- **[Outbound Example](examples/outbound/)** - Agent-initiated SMS, WhatsApp, and Voice conversations
 
 ## Next Steps
 

--- a/getting_started/examples/.env.example
+++ b/getting_started/examples/.env.example
@@ -12,6 +12,9 @@ TWILIO_CONVERSATION_CONFIGURATION_ID=conv_configuration_xxxxxxxxxxxxxxxxxxxxxxxx
 # Optional - Voice Channel (domain only, without https:// prefix)
 TWILIO_VOICE_PUBLIC_DOMAIN=your-domain.ngrok.app
 
+# Optional - WhatsApp Channel (include whatsapp: prefix, e.g., whatsapp:+15551234567)
+# TWILIO_WHATSAPP_NUMBER=whatsapp:+1xxxxxxxxxx
+
 # Optional - Twilio Region (routes API requests to a specific region)
 # TWILIO_REGION=
 

--- a/getting_started/examples/features/whatsapp/package-lock.json
+++ b/getting_started/examples/features/whatsapp/package-lock.json
@@ -1,24 +1,25 @@
 {
-  "name": "tac-example-outbound",
+  "name": "tac-example-whatsapp",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tac-example-outbound",
+      "name": "tac-example-whatsapp",
       "version": "1.0.0",
       "dependencies": {
         "dotenv": "^16.4.5",
         "openai": "^4.73.0",
-        "twilio-agent-connect": "file:../../.."
+        "twilio-agent-connect": "file:../../../.."
       },
       "devDependencies": {
         "@types/node": "^22.10.2",
+        "pino-pretty": "^13.0.0",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2"
       }
     },
-    "../../..": {
+    "../../../..": {
       "name": "twilio-agent-connect",
       "version": "1.0.0",
       "license": "MIT",
@@ -546,6 +547,16 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -559,6 +570,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -569,6 +587,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/delayed-stream": {
@@ -604,6 +632,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -702,6 +740,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -799,9 +851,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.7",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
-      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -851,9 +903,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -862,6 +914,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -869,6 +928,16 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -899,6 +968,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -947,6 +1026,26 @@
         }
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/openai": {
       "version": "4.104.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
@@ -992,6 +1091,52 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -1000,6 +1145,56 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tr46": {
@@ -1029,7 +1224,7 @@
       }
     },
     "node_modules/twilio-agent-connect": {
-      "resolved": "../../..",
+      "resolved": "../../../..",
       "link": true
     },
     "node_modules/typescript": {
@@ -1076,6 +1271,13 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/getting_started/examples/features/whatsapp/package.json
+++ b/getting_started/examples/features/whatsapp/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "tac-example-whatsapp",
+  "version": "1.0.0",
+  "description": "WhatsApp channel example for Twilio Agent Connect",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts | pino-pretty",
+    "start": "tsx watch src/index.ts | pino-pretty"
+  },
+  "dependencies": {
+    "twilio-agent-connect": "file:../../../..",
+    "dotenv": "^16.4.5",
+    "openai": "^4.73.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "pino-pretty": "^13.0.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/getting_started/examples/features/whatsapp/src/index.ts
+++ b/getting_started/examples/features/whatsapp/src/index.ts
@@ -1,8 +1,8 @@
 /**
  * Example: WhatsApp Channel with OpenAI Integration
  *
- * Demonstrates WhatsApp channel with TAC memory injection.
- * WhatsApp supports rich media and interactive messaging.
+ * Demonstrates WhatsApp text messaging with TAC memory injection.
+ * This example sends and receives text messages only.
  *
  * Requires OPENAI_API_KEY and TWILIO_WHATSAPP_NUMBER in addition to standard TAC env vars.
  *

--- a/getting_started/examples/features/whatsapp/src/index.ts
+++ b/getting_started/examples/features/whatsapp/src/index.ts
@@ -100,17 +100,12 @@ async function handleMessageReady(params: {
 tac.onMessageReady(handleMessageReady);
 
 // Create and start server (auto-discovers WhatsApp channel)
-const server = new TACServer(tac, {
-  voice: {
-    host: '0.0.0.0',
-    port: 8000,
-  },
-});
+const server = new TACServer(tac);
 
 server
   .start()
   .then(() => {
-    console.log('WhatsApp server started successfully on port 8000');
+    console.log('WhatsApp server started successfully');
     console.log('Send a WhatsApp message to your configured number to test');
   })
   .catch(error => {

--- a/getting_started/examples/features/whatsapp/src/index.ts
+++ b/getting_started/examples/features/whatsapp/src/index.ts
@@ -1,0 +1,132 @@
+/**
+ * Example: WhatsApp Channel with OpenAI Integration
+ *
+ * Demonstrates WhatsApp channel with TAC memory injection.
+ * WhatsApp supports rich media and interactive messaging.
+ *
+ * Requires OPENAI_API_KEY and TWILIO_WHATSAPP_NUMBER in addition to standard TAC env vars.
+ *
+ * Usage:
+ *   npm run dev
+ *
+ * Then send messages to your Twilio WhatsApp number from your phone.
+ */
+
+import { config } from 'dotenv';
+import OpenAI from 'openai';
+import {
+  TAC,
+  TACConfig,
+  WhatsAppChannel,
+  ConversationSession,
+  TACMemoryResponse,
+  ConversationId,
+  ProfileId,
+  TACServer,
+  MemoryPromptBuilder,
+} from 'twilio-agent-connect';
+
+// Load environment variables from parent directory
+config({ path: '../../.env' });
+
+// Initialize OpenAI client
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+const tac = await TAC.create({ config: TACConfig.fromEnv() });
+
+// Memory mode: "always" fetches memory with query on every message for semantic search
+// Alternative: "never" (no automatic retrieval, use manual tac.retrieveMemory() in callback)
+const whatsappChannel = new WhatsAppChannel(tac, {
+  memoryMode: 'always',
+});
+
+// Register channel
+tac.registerChannel(whatsappChannel);
+
+// Store conversation history per conversation
+const conversationMessages: Record<string, OpenAI.Chat.ChatCompletionMessageParam[]> = {};
+
+const SYSTEM_INSTRUCTIONS =
+  'You are a friendly, helpful AI customer service agent. ' +
+  'Keep responses conversational and concise. ' +
+  'Do not use markdown formatting.';
+
+async function handleMessageReady(params: {
+  conversationId: ConversationId;
+  profileId: ProfileId | undefined;
+  message: string;
+  author: string;
+  memory: TACMemoryResponse | undefined;
+  session: ConversationSession;
+}): Promise<string> {
+  const { conversationId, message, memory: memoryResponse, session: context } = params;
+  const convId = conversationId as string;
+
+  try {
+    // Initialize conversation history if needed
+    if (!conversationMessages[convId]) {
+      conversationMessages[convId] = [];
+    }
+
+    // Add user message to history
+    conversationMessages[convId].push({
+      role: 'user',
+      content: message,
+    });
+
+    // Build system prompt with memory context
+    const memoryContext = MemoryPromptBuilder.build(memoryResponse, context);
+    const systemContent = SYSTEM_INSTRUCTIONS + (memoryContext ? `\n\n${memoryContext}` : '');
+
+    const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+      { role: 'system', content: systemContent },
+      ...conversationMessages[convId],
+    ];
+
+    // Call OpenAI
+    const response = await openai.chat.completions.create({
+      model: 'gpt-5.4-mini',
+      messages,
+    });
+
+    const llmResponse = response.choices[0]?.message?.content ?? '';
+
+    // Add assistant response to history
+    conversationMessages[convId].push({
+      role: 'assistant',
+      content: llmResponse,
+    });
+
+    console.log(`[${convId}] Customer: ${message}`);
+    console.log(`[${convId}] Agent: ${llmResponse}`);
+
+    return llmResponse;
+  } catch (error) {
+    console.error(`Error processing WhatsApp message for conversation ${convId}:`, error);
+    return 'Sorry, I encountered an error processing your message.';
+  }
+}
+
+// Register message handler
+tac.onMessageReady(handleMessageReady);
+
+// Create and start server (auto-discovers WhatsApp channel)
+const server = new TACServer(tac, {
+  voice: {
+    host: '0.0.0.0',
+    port: 8000,
+  },
+});
+
+server
+  .start()
+  .then(() => {
+    console.log('WhatsApp server started successfully on port 8000');
+    console.log('Send a WhatsApp message to your configured number to test');
+  })
+  .catch(error => {
+    console.error('Failed to start server:', error);
+    process.exit(1);
+  });

--- a/getting_started/examples/features/whatsapp/src/index.ts
+++ b/getting_started/examples/features/whatsapp/src/index.ts
@@ -18,12 +18,9 @@ import {
   TAC,
   TACConfig,
   WhatsAppChannel,
-  ConversationSession,
-  TACMemoryResponse,
   ConversationId,
   ProfileId,
   TACServer,
-  MemoryPromptBuilder,
 } from 'twilio-agent-connect';
 
 // Load environment variables from parent directory
@@ -36,11 +33,7 @@ const openai = new OpenAI({
 
 const tac = await TAC.create({ config: TACConfig.fromEnv() });
 
-// Memory mode: "always" fetches memory with query on every message for semantic search
-// Alternative: "never" (no automatic retrieval, use manual tac.retrieveMemory() in callback)
-const whatsappChannel = new WhatsAppChannel(tac, {
-  memoryMode: 'always',
-});
+const whatsappChannel = new WhatsAppChannel(tac);
 
 // Register channel
 tac.registerChannel(whatsappChannel);
@@ -58,10 +51,8 @@ async function handleMessageReady(params: {
   profileId: ProfileId | undefined;
   message: string;
   author: string;
-  memory: TACMemoryResponse | undefined;
-  session: ConversationSession;
 }): Promise<string> {
-  const { conversationId, message, memory: memoryResponse, session: context } = params;
+  const { conversationId, message } = params;
   const convId = conversationId as string;
 
   try {
@@ -76,12 +67,8 @@ async function handleMessageReady(params: {
       content: message,
     });
 
-    // Build system prompt with memory context
-    const memoryContext = MemoryPromptBuilder.build(memoryResponse, context);
-    const systemContent = SYSTEM_INSTRUCTIONS + (memoryContext ? `\n\n${memoryContext}` : '');
-
     const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
-      { role: 'system', content: systemContent },
+      { role: 'system', content: SYSTEM_INSTRUCTIONS },
       ...conversationMessages[convId],
     ];
 

--- a/getting_started/examples/features/whatsapp/tsconfig.json
+++ b/getting_started/examples/features/whatsapp/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/getting_started/examples/outbound/README.md
+++ b/getting_started/examples/outbound/README.md
@@ -1,12 +1,16 @@
 # Outbound Conversations Example
 
-This example demonstrates how to initiate **outbound (agent-initiated) conversations** using Twilio Agent Connect (TAC). The agent reaches out to a customer via SMS or Voice, then handles a full conversation loop powered by OpenAI.
+This example demonstrates how to initiate **outbound (agent-initiated) conversations** using Twilio Agent Connect (TAC). The agent reaches out to a customer via SMS, WhatsApp, or Voice, then handles a full conversation loop powered by OpenAI.
 
 ## Supported Channels
 
 ### SMS
 
 The agent sends an initial SMS to the customer. When the customer replies, the message arrives via Conversation Orchestrator webhook and the agent responds using OpenAI.
+
+### WhatsApp
+
+The agent sends an initial WhatsApp message to the customer. When the customer replies, the message arrives via Conversation Orchestrator webhook and the agent responds using OpenAI. Requires `TWILIO_WHATSAPP_NUMBER` to be configured in your environment.
 
 ### Voice
 
@@ -64,6 +68,12 @@ TWILIO_CONVERSATION_CONFIGURATION_ID=conv_configuration_xxxxxxxxxxxxxxxxxxxxxxxx
 OPENAI_API_KEY=sk-proj-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
+Optional for WhatsApp:
+
+```bash
+TWILIO_WHATSAPP_NUMBER=whatsapp:+1xxxxxxxxxx
+```
+
 Required for Voice:
 
 ```bash
@@ -104,6 +114,16 @@ npm run dev -- --to +16505551234 --channel sms --message "Hi! This is a follow-u
 
 The agent sends the initial message, then waits for the customer to reply. Each reply triggers an OpenAI-powered response.
 
+### WhatsApp
+
+Send an outbound WhatsApp message:
+
+```bash
+npm run dev -- --to whatsapp:+16505551234 --channel whatsapp --message "Hi! This is a follow-up about your recent order."
+```
+
+The agent sends the initial WhatsApp message, then waits for the customer to reply. Each reply triggers an OpenAI-powered response. Note: `TWILIO_WHATSAPP_NUMBER` must be configured in your `.env` file.
+
 ### Voice
 
 Place an outbound call:
@@ -126,14 +146,14 @@ Note: the customer's "hello?" may interrupt the greeting. For most outbound use 
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `--to` | Yes | Recipient address (E.164 phone number for SMS/Voice) |
-| `--channel` | Yes | Channel type: `sms` or `voice` |
-| `--message` | SMS only | Initial outbound message text |
+| `--to` | Yes | Recipient address (E.164 phone number for SMS/Voice, or `whatsapp:+1234567890` for WhatsApp) |
+| `--channel` | Yes | Channel type: `sms`, `whatsapp`, or `voice` |
+| `--message` | SMS/WhatsApp | Initial outbound message text (required for `sms` and `whatsapp` channels) |
 | `--welcome-greeting` | No | Voice greeting spoken when the call is answered |
 
 ## How It Works
 
-### SMS Flow
+### SMS/WhatsApp Flow
 
 ```
 CLI args → Start server → Send SMS via CO Send API

--- a/getting_started/examples/outbound/src/index.ts
+++ b/getting_started/examples/outbound/src/index.ts
@@ -1,12 +1,13 @@
 /**
- * Example: Outbound Conversations with SMS and Voice
+ * Example: Outbound Conversations with SMS, WhatsApp, and Voice
  *
  * Demonstrates agent-initiated (outbound) conversations using TAC.
- * Sends an SMS or places a voice call, then handles the full conversation
- * loop with OpenAI.
+ * Sends an SMS, WhatsApp message, or places a voice call, then handles
+ * the full conversation loop with OpenAI.
  *
  * Usage:
  *   npm run dev -- --to +16505551234 --channel sms --message "Hello!"
+ *   npm run dev -- --to whatsapp:+16505551234 --channel whatsapp --message "Hello!"
  *   npm run dev -- --to +16505551234 --channel voice
  */
 
@@ -18,6 +19,7 @@ import {
   TACConfig,
   VoiceChannel,
   SMSChannel,
+  WhatsAppChannel,
   ConversationId,
   ChannelType,
   ProfileId,
@@ -41,24 +43,25 @@ const { values: args } = parseArgs({
 });
 
 const to = args.to;
-const channel = args.channel as 'sms' | 'voice' | undefined;
+const channel = args.channel as 'sms' | 'whatsapp' | 'voice' | undefined;
 const message = args.message;
 const welcomeGreeting = args['welcome-greeting'];
 
 if (!to || !channel) {
   console.error('Usage:');
   console.error('  npm run dev -- --to <address> --channel sms --message "Hello!"');
+  console.error('  npm run dev -- --to <address> --channel whatsapp --message "Hello!"');
   console.error('  npm run dev -- --to <address> --channel voice [--welcome-greeting "Hi!"]');
   process.exit(1);
 }
 
-if (channel !== 'sms' && channel !== 'voice') {
-  console.error(`Invalid channel "${channel}". Must be "sms" or "voice".`);
+if (channel !== 'sms' && channel !== 'whatsapp' && channel !== 'voice') {
+  console.error(`Invalid channel "${channel}". Must be "sms", "whatsapp", or "voice".`);
   process.exit(1);
 }
 
-if (channel === 'sms' && !message) {
-  console.error('--message is required for SMS channel.');
+if ((channel === 'sms' || channel === 'whatsapp') && !message) {
+  console.error(`--message is required for ${channel} channel.`);
   process.exit(1);
 }
 
@@ -73,9 +76,13 @@ const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 const tac = await TAC.create({ config: TACConfig.fromEnv() });
 const voiceChannel = new VoiceChannel(tac);
 const smsChannel = new SMSChannel(tac);
+const whatsappChannel = process.env.TWILIO_WHATSAPP_NUMBER ? new WhatsAppChannel(tac) : null;
 
 tac.registerChannel(voiceChannel);
 tac.registerChannel(smsChannel);
+if (whatsappChannel) {
+  tac.registerChannel(whatsappChannel);
+}
 
 // ---------------------------------------------------------------------------
 // Conversation state
@@ -206,6 +213,20 @@ server
         message: message!,
       });
       console.log(`SMS sent to ${to} (conversation: ${result.conversationId})`);
+      console.log(`[${result.conversationId}] Agent: ${message}`);
+      console.log('\nWaiting for replies... (Ctrl+C to exit)\n');
+    } else if (channel === 'whatsapp') {
+      if (!whatsappChannel) {
+        console.error(
+          'TWILIO_WHATSAPP_NUMBER is required for WhatsApp channel. Set it in your .env file (e.g., whatsapp:+15551234567)'
+        );
+        process.exit(1);
+      }
+      const result = await whatsappChannel.initiateOutboundConversation({
+        to,
+        message: message!,
+      });
+      console.log(`WhatsApp message sent to ${to} (conversation: ${result.conversationId})`);
       console.log(`[${result.conversationId}] Agent: ${message}`);
       console.log('\nWaiting for replies... (Ctrl+C to exit)\n');
     } else if (channel === 'voice') {

--- a/getting_started/examples/outbound/src/index.ts
+++ b/getting_started/examples/outbound/src/index.ts
@@ -60,6 +60,13 @@ if (channel !== 'sms' && channel !== 'whatsapp' && channel !== 'voice') {
   process.exit(1);
 }
 
+if (channel === 'whatsapp' && !to.startsWith('whatsapp:')) {
+  console.error(
+    'Invalid WhatsApp destination. --to must include the "whatsapp:" prefix, e.g. "whatsapp:+16505551234".'
+  );
+  process.exit(1);
+}
+
 if ((channel === 'sms' || channel === 'whatsapp') && !message) {
   console.error(`--message is required for ${channel} channel.`);
   process.exit(1);

--- a/packages/core/src/channels/messaging.ts
+++ b/packages/core/src/channels/messaging.ts
@@ -711,8 +711,8 @@ export abstract class MessagingChannel extends BaseChannel {
   /**
    * Find or mint a Conversation Memory profile for a customer being promoted from UNKNOWN.
    *
-   * Only resolves for phone-based channels (SMS, VOICE). Looks up by phone
-   * identifier first; on miss, creates a new profile using the configured
+   * Only resolves for phone-based channels (SMS, VOICE, WHATSAPP). Looks up by phone
+   * or WhatsApp identifier first; on miss, creates a new profile using the configured
    * phone trait group/field. Returns undefined on any failure — the caller
    * still promotes the participant, just without a `profileId` attached.
    */
@@ -720,7 +720,7 @@ export abstract class MessagingChannel extends BaseChannel {
     customer: ConversationParticipant,
     channel: string
   ): Promise<string | undefined> {
-    if (channel !== 'SMS' && channel !== 'VOICE') return undefined;
+    if (channel !== 'SMS' && channel !== 'VOICE' && channel !== 'WHATSAPP') return undefined;
 
     const memoryClient = this.tac.getMemoryClient();
     if (!memoryClient || !this.tac.getMemoryStoreId()) return undefined;
@@ -730,8 +730,11 @@ export abstract class MessagingChannel extends BaseChannel {
       : undefined;
     if (!phoneAddress) return undefined;
 
+    // Determine identity type: 'whatsapp' for WhatsApp channel, 'phone' for SMS/Voice
+    const identityType = channel === 'WHATSAPP' ? 'whatsapp' : 'phone';
+
     try {
-      const lookup = await memoryClient.lookupProfile('phone', phoneAddress);
+      const lookup = await memoryClient.lookupProfile(identityType, phoneAddress);
       if (lookup.profiles && lookup.profiles.length > 0) {
         return lookup.profiles[0];
       }

--- a/packages/core/src/channels/messaging.ts
+++ b/packages/core/src/channels/messaging.ts
@@ -888,13 +888,13 @@ export abstract class MessagingChannel extends BaseChannel {
   }
 
   /**
-   * Shared outbound conversation initiation for messaging channels (SMS/Chat).
+   * Shared outbound conversation initiation for messaging channels (SMS/Chat/WhatsApp).
    *
    * Handles the full flow: create conversation → find participants → start
    * session → send initial message → error cleanup.
    */
   protected async initiateOutboundMessagingConversation(params: {
-    channel: 'SMS' | 'CHAT';
+    channel: 'SMS' | 'CHAT' | 'WHATSAPP';
     to: string;
     from: string;
     message: string;

--- a/packages/core/src/channels/whatsapp.ts
+++ b/packages/core/src/channels/whatsapp.ts
@@ -1,0 +1,176 @@
+import {
+  ChannelType,
+  ConversationAddress,
+  ConversationId,
+  SendMessageActionRequest,
+  InitiateMessagingConversationOptions,
+  InitiateMessagingConversationOptionsSchema,
+  InitiateConversationResult,
+} from '../types/index';
+import { MessagingChannel } from './messaging';
+import { maskAddress } from '../util/log-redaction';
+
+/**
+ * WhatsApp Channel implementation for Twilio Conversations Service
+ *
+ * Handles WhatsApp conversations through webhook events from Twilio.
+ * Automatically retrieves user memory and manages conversation lifecycle.
+ *
+ * WhatsApp uses WhatsApp sender phone numbers configured in TACConfig
+ * (via TWILIO_WHATSAPP_NUMBER). Address format: whatsapp:+1234567890
+ */
+export class WhatsAppChannel extends MessagingChannel {
+  public get channelType(): ChannelType {
+    return 'whatsapp';
+  }
+
+  protected isDefaultAgentAddress(authorAddress: string): boolean {
+    if (!this.config.whatsappNumber) {
+      throw new Error(
+        'whatsappNumber is required for WhatsApp channel. ' +
+          'Please set TWILIO_WHATSAPP_NUMBER environment variable or ' +
+          'provide whatsappNumber in TACConfig.'
+      );
+    }
+    return authorAddress === this.config.whatsappNumber;
+  }
+
+  protected getAgentAddress(_conversationId: ConversationId): ConversationAddress {
+    if (!this.config.whatsappNumber) {
+      throw new Error(
+        'whatsappNumber is required for WhatsApp channel. ' +
+          'Please set TWILIO_WHATSAPP_NUMBER environment variable or ' +
+          'provide whatsappNumber in TACConfig.'
+      );
+    }
+    return { channel: 'WHATSAPP', address: this.config.whatsappNumber };
+  }
+
+  /**
+   * Send WhatsApp response using the Conversation Orchestrator Actions API (SEND_MESSAGE).
+   *
+   * Reads the agent and customer participant ids stashed on the session by
+   * inbound reconciliation or outbound initiation. Missing ids are a misuse —
+   * `sendResponse` is only expected to be called after an inbound webhook
+   * (COMMUNICATION_CREATED → reconcile) or after `initiateOutboundConversation`,
+   * both of which populate the session.
+   */
+  public async sendResponse(
+    conversationId: ConversationId,
+    message: string,
+    metadata?: Record<string, unknown>
+  ): Promise<void> {
+    this.logger.debug(
+      {
+        conversation_id: conversationId,
+        message_length: message.length,
+        operation: 'send_response',
+      },
+      'Sending WhatsApp response'
+    );
+
+    try {
+      const session = this.getConversationSession(conversationId);
+
+      if (!session || !session.authorInfo || !session.aiAgentInfo) {
+        throw new Error(
+          `Unable to send WhatsApp: sendResponse called without a reconciled session for ` +
+            `conversation ${conversationId}. Wait for an inbound webhook or call ` +
+            `initiateOutboundConversation first.`
+        );
+      }
+
+      const customerParticipantId = session.authorInfo.participantId;
+      const agentParticipantId = session.aiAgentInfo.participantId;
+      if (!customerParticipantId || !agentParticipantId) {
+        throw new Error(
+          `Unable to send WhatsApp: session for conversation ${conversationId} is missing ` +
+            `participant ids.`
+        );
+      }
+
+      const channelId =
+        typeof session.metadata?.channelId === 'string' ? session.metadata.channelId : undefined;
+
+      this.logger.debug(
+        {
+          conversation_id: conversationId,
+          recipient_address: maskAddress(session.authorInfo.address),
+          recipient_participant_id: customerParticipantId,
+          agent_participant_id: agentParticipantId,
+        },
+        'Sending WhatsApp via Actions API'
+      );
+
+      const actionRequest: SendMessageActionRequest = {
+        type: 'SEND_MESSAGE',
+        payload: {
+          from: {
+            channel: 'WHATSAPP',
+            participantId: agentParticipantId,
+          },
+          to: [
+            {
+              channel: 'WHATSAPP',
+              participantId: customerParticipantId,
+            },
+          ],
+          content: { text: message },
+          ...(channelId ? { channelSettings: { channelId } } : {}),
+        },
+      };
+
+      await this.conversationClient.createAction(conversationId, actionRequest);
+
+      this.logger.info(
+        {
+          conversation_id: conversationId,
+          recipient_address: maskAddress(session.authorInfo.address),
+        },
+        'WhatsApp sent successfully via Actions API'
+      );
+    } catch (error) {
+      this.logger.error({ err: error, conversation_id: conversationId }, 'Send response error');
+      this.handleError(error instanceof Error ? error : new Error(String(error)), {
+        conversationId,
+        message,
+        metadata,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Initiate an outbound WhatsApp conversation
+   *
+   * Creates a conversation via Conversation Orchestrator, adds customer and
+   * agent participants, then sends the initial message via the Actions API.
+   * The sender is always `config.whatsappNumber`.
+   */
+  public async initiateOutboundConversation(
+    options: InitiateMessagingConversationOptions
+  ): Promise<InitiateConversationResult> {
+    const validated = InitiateMessagingConversationOptionsSchema.parse(options);
+
+    if (!this.config.whatsappNumber) {
+      throw new Error(
+        'whatsappNumber is required for WhatsApp channel. ' +
+          'Please set TWILIO_WHATSAPP_NUMBER environment variable or ' +
+          'provide whatsappNumber in TACConfig.'
+      );
+    }
+
+    this.logger.info(
+      { to: maskAddress(validated.to), message_length: validated.message.length },
+      'Initiating outbound WhatsApp conversation'
+    );
+
+    return this.initiateOutboundMessagingConversation({
+      channel: 'WHATSAPP',
+      to: validated.to,
+      from: this.config.whatsappNumber,
+      message: validated.message,
+      ...(validated.metadata ? { metadata: validated.metadata } : {}),
+    });
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,8 @@ export type {
 
 export { SMSChannel } from './channels/sms';
 
+export { WhatsAppChannel } from './channels/whatsapp';
+
 export { ChatChannel } from './channels/chat';
 export type {
   ChatChannelConfig,

--- a/packages/core/src/lib/config.ts
+++ b/packages/core/src/lib/config.ts
@@ -22,6 +22,7 @@ export class TACConfig {
   public readonly apiKey: string;
   public readonly apiSecret: string;
   public readonly phoneNumber: string;
+  public readonly whatsappNumber?: string;
   public readonly memoryConfig: TACConfigData['memoryConfig'];
   public readonly conversationConfigurationId?: string;
   public readonly voicePublicDomain?: string;
@@ -48,6 +49,9 @@ export class TACConfig {
     this.apiKey = validatedConfig.apiKey;
     this.apiSecret = validatedConfig.apiSecret;
     this.phoneNumber = validatedConfig.phoneNumber;
+    if (validatedConfig.whatsappNumber) {
+      this.whatsappNumber = validatedConfig.whatsappNumber;
+    }
     // Assign the validated memory config directly; schema parsing already validates shape and applies defaults
     this.memoryConfig = validatedConfig.memoryConfig;
     if (validatedConfig.conversationConfigurationId) {
@@ -84,6 +88,7 @@ export class TACConfig {
    * - TWILIO_PHONE_NUMBER: Phone number for voice and SMS channels
    *
    * Optional environment variables:
+   * - TWILIO_WHATSAPP_NUMBER: WhatsApp number for WhatsApp channel (e.g., 'whatsapp:+1234567890')
    * - TWILIO_CONVERSATION_CONFIGURATION_ID: Conversation Orchestrator configuration ID (enables orchestrated mode)
    * - TWILIO_VOICE_PUBLIC_DOMAIN: Public domain for voice WebSocket connections (domain only, without protocol/port/path, e.g., 'abc123.ngrok.app')
    * - TWILIO_REGION: Twilio region subdomain for API routing (e.g. transforms base URLs to `https://{product}.{region}.twilio.com`)
@@ -194,6 +199,7 @@ export class TACConfig {
       apiKey: process.env[EnvironmentVariables.TWILIO_API_KEY]!,
       apiSecret: process.env[EnvironmentVariables.TWILIO_API_SECRET]!,
       phoneNumber: process.env[EnvironmentVariables.TWILIO_PHONE_NUMBER]!,
+      whatsappNumber: process.env[EnvironmentVariables.TWILIO_WHATSAPP_NUMBER] || undefined,
       memoryConfig: {
         traitGroups,
         observationsLimit: parseIntEnv(

--- a/packages/core/src/lib/tac.ts
+++ b/packages/core/src/lib/tac.ts
@@ -50,8 +50,8 @@ export type ConversationEndedCallback = (params: {
 /**
  * Main Twilio Agent Connect class
  *
- * Central orchestrator that manages configuration, channels, callbacks,
- * and coordinates between memory, conversations, and LLM integrations.
+ * Central orchestrator that manages configuration, channels (SMS, WhatsApp, Chat, Voice),
+ * callbacks, and coordinates between memory, conversations, and LLM integrations.
  */
 export class TAC {
   private static readonly FACTORY_TOKEN = Symbol('TAC.create');

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 /**
  * Channel types supported by the framework
  */
-export const ChannelTypeSchema = z.enum(['sms', 'voice', 'chat']);
+export const ChannelTypeSchema = z.enum(['sms', 'voice', 'chat', 'whatsapp']);
 export type ChannelType = z.infer<typeof ChannelTypeSchema>;
 
 /**
@@ -36,6 +36,10 @@ export const TACConfigSchema = z.object({
   apiKey: z.string().min(1, 'Twilio API Key is required'),
   apiSecret: z.string().min(1, 'Twilio API Secret is required'),
   phoneNumber: z.string().min(1, 'Twilio Phone Number is required'),
+  whatsappNumber: z
+    .string()
+    .regex(/^whatsapp:\+\d+$/, 'WhatsApp number must be in format: whatsapp:+1234567890')
+    .optional(),
   memoryConfig: TwilioMemoryConfigSchema.default({}),
   conversationConfigurationId: z
     .string()
@@ -85,6 +89,7 @@ export const EnvironmentVariables = {
   TWILIO_API_KEY: 'TWILIO_API_KEY',
   TWILIO_API_SECRET: 'TWILIO_API_SECRET',
   TWILIO_PHONE_NUMBER: 'TWILIO_PHONE_NUMBER',
+  TWILIO_WHATSAPP_NUMBER: 'TWILIO_WHATSAPP_NUMBER',
   TWILIO_MEMORY_PROFILE_TRAIT_GROUPS: 'TWILIO_MEMORY_PROFILE_TRAIT_GROUPS',
   TWILIO_MEMORY_OBSERVATIONS_LIMIT: 'TWILIO_MEMORY_OBSERVATIONS_LIMIT',
   TWILIO_MEMORY_SUMMARIES_LIMIT: 'TWILIO_MEMORY_SUMMARIES_LIMIT',

--- a/packages/server/src/lib/server.ts
+++ b/packages/server/src/lib/server.ts
@@ -55,7 +55,10 @@ export interface TACServerConfig {
   /** Voice channel instance (alternative to registering on TAC) */
   voiceChannel?: VoiceChannel;
 
-  /** Messaging channel instances — webhooks are fanned out to all (alternative to registering on TAC) */
+  /**
+   * Messaging channel instances — webhooks are fanned out to all (alternative to registering on TAC).
+   * If omitted, TACServer automatically discovers all registered messaging channels (SMS, WhatsApp, Chat).
+   */
   messagingChannels?: MessagingChannel[];
 }
 
@@ -137,10 +140,11 @@ export class TACServer {
     this.messagingChannels =
       config.messagingChannels ??
       (
-        [tac.getChannel<MessagingChannel>('sms'), tac.getChannel<MessagingChannel>('chat')] as (
-          | MessagingChannel
-          | undefined
-        )[]
+        [
+          tac.getChannel<MessagingChannel>('sms'),
+          tac.getChannel<MessagingChannel>('chat'),
+          tac.getChannel<MessagingChannel>('whatsapp'),
+        ] as (MessagingChannel | undefined)[]
       ).filter((ch): ch is MessagingChannel => ch != null);
 
     if (this.messagingChannels.length === 0) {

--- a/packages/server/src/lib/server.ts
+++ b/packages/server/src/lib/server.ts
@@ -55,10 +55,7 @@ export interface TACServerConfig {
   /** Voice channel instance (alternative to registering on TAC) */
   voiceChannel?: VoiceChannel;
 
-  /**
-   * Messaging channel instances — webhooks are fanned out to all (alternative to registering on TAC).
-   * If omitted, TACServer automatically discovers all registered messaging channels (SMS, WhatsApp, Chat).
-   */
+  /** Messaging channel instances — webhooks are fanned out to all (alternative to registering on TAC) */
   messagingChannels?: MessagingChannel[];
 }
 

--- a/tests/sms-channel.test.ts
+++ b/tests/sms-channel.test.ts
@@ -777,6 +777,24 @@ describe('SMS Channel', () => {
       };
       const retrieveMemorySpy = vi.spyOn(tac, 'retrieveMemory').mockResolvedValue(mockMemory as any);
 
+      // Mock reconcileParticipants for the new channel instance
+      vi.spyOn(channelAlways as any, 'reconcileParticipants').mockResolvedValue([
+        {
+          id: 'PA111',
+          conversationId: 'CHtest123456789',
+          accountId: 'ACtest123456789',
+          type: 'AI_AGENT',
+          addresses: [{ channel: 'SMS', address: '+15551234567' }],
+        },
+        {
+          id: 'PA222',
+          conversationId: 'CHtest123456789',
+          accountId: 'ACtest123456789',
+          type: 'CUSTOMER',
+          addresses: [{ channel: 'SMS', address: '+15559876543' }],
+        },
+      ]);
+
       const webhookPayload = {
         eventType: 'COMMUNICATION_CREATED',
         data: {
@@ -803,6 +821,24 @@ describe('SMS Channel', () => {
       const retrieveMemorySpy = vi
         .spyOn(tac, 'retrieveMemory')
         .mockRejectedValue(new Error('Memory API error'));
+
+      // Mock reconcileParticipants for the new channel instance
+      vi.spyOn(channelAlways as any, 'reconcileParticipants').mockResolvedValue([
+        {
+          id: 'PA111',
+          conversationId: 'CHtest123456789',
+          accountId: 'ACtest123456789',
+          type: 'AI_AGENT',
+          addresses: [{ channel: 'SMS', address: '+15551234567' }],
+        },
+        {
+          id: 'PA222',
+          conversationId: 'CHtest123456789',
+          accountId: 'ACtest123456789',
+          type: 'CUSTOMER',
+          addresses: [{ channel: 'SMS', address: '+15559876543' }],
+        },
+      ]);
 
       const webhookPayload = {
         eventType: 'COMMUNICATION_CREATED',

--- a/tests/whatsapp-channel.test.ts
+++ b/tests/whatsapp-channel.test.ts
@@ -284,4 +284,142 @@ describe('WhatsApp Channel', () => {
       });
     });
   });
+
+  describe('memory retrieval', () => {
+    it('should not retrieve memory when memoryMode is "never"', async () => {
+      const channelNever = new WhatsAppChannel(tac, { memoryMode: 'never' });
+      const retrieveMemorySpy = vi.spyOn(tac, 'retrieveMemory');
+
+      // Mock reconcileParticipants
+      vi.spyOn(channelNever as any, 'reconcileParticipants').mockResolvedValue([
+        {
+          id: 'PA111',
+          conversationId: 'CHtest123456789',
+          accountId: 'ACtest123456789',
+          type: 'AI_AGENT',
+          addresses: [{ channel: 'WHATSAPP', address: 'whatsapp:+15551234567' }],
+        },
+        {
+          id: 'PA222',
+          conversationId: 'CHtest123456789',
+          accountId: 'ACtest123456789',
+          type: 'CUSTOMER',
+          addresses: [{ channel: 'WHATSAPP', address: 'whatsapp:+15559876543' }],
+        },
+      ]);
+
+      const webhookPayload = {
+        eventType: 'COMMUNICATION_CREATED',
+        data: {
+          conversationId: 'CHtest123456789',
+          content: {
+            type: 'TEXT',
+            text: 'Hello',
+          },
+          author: {
+            address: 'whatsapp:+15559876543',
+            channel: 'WHATSAPP',
+          },
+        },
+      };
+
+      await channelNever.processWebhook(webhookPayload);
+
+      // Memory should NOT be retrieved
+      expect(retrieveMemorySpy).not.toHaveBeenCalled();
+    });
+
+    it('should retrieve memory when memoryMode is "always"', async () => {
+      const channelAlways = new WhatsAppChannel(tac, { memoryMode: 'always' });
+      const mockMemory = {
+        observations: [{ id: 'obs1', content: 'Test observation' }],
+        summaries: [],
+        communications: [],
+      };
+      const retrieveMemorySpy = vi.spyOn(tac, 'retrieveMemory').mockResolvedValue(mockMemory as any);
+
+      // Mock reconcileParticipants for the new channel instance
+      vi.spyOn(channelAlways as any, 'reconcileParticipants').mockResolvedValue([
+        {
+          id: 'PA111',
+          conversationId: 'CHtest123456789',
+          accountId: 'ACtest123456789',
+          type: 'AI_AGENT',
+          addresses: [{ channel: 'WHATSAPP', address: 'whatsapp:+15551234567' }],
+        },
+        {
+          id: 'PA222',
+          conversationId: 'CHtest123456789',
+          accountId: 'ACtest123456789',
+          type: 'CUSTOMER',
+          addresses: [{ channel: 'WHATSAPP', address: 'whatsapp:+15559876543' }],
+        },
+      ]);
+
+      const webhookPayload = {
+        eventType: 'COMMUNICATION_CREATED',
+        data: {
+          conversationId: 'CHtest123456789',
+          content: {
+            type: 'TEXT',
+            text: 'Hello',
+          },
+          author: {
+            address: 'whatsapp:+15559876543',
+            channel: 'WHATSAPP',
+          },
+        },
+      };
+
+      await channelAlways.processWebhook(webhookPayload);
+
+      // Memory should be retrieved
+      expect(retrieveMemorySpy).toHaveBeenCalled();
+    });
+
+    it('should handle memory retrieval errors gracefully when memoryMode is "always"', async () => {
+      const channelAlways = new WhatsAppChannel(tac, { memoryMode: 'always' });
+      const retrieveMemorySpy = vi
+        .spyOn(tac, 'retrieveMemory')
+        .mockRejectedValue(new Error('Memory API error'));
+
+      // Mock reconcileParticipants for the new channel instance
+      vi.spyOn(channelAlways as any, 'reconcileParticipants').mockResolvedValue([
+        {
+          id: 'PA111',
+          conversationId: 'CHtest123456789',
+          accountId: 'ACtest123456789',
+          type: 'AI_AGENT',
+          addresses: [{ channel: 'WHATSAPP', address: 'whatsapp:+15551234567' }],
+        },
+        {
+          id: 'PA222',
+          conversationId: 'CHtest123456789',
+          accountId: 'ACtest123456789',
+          type: 'CUSTOMER',
+          addresses: [{ channel: 'WHATSAPP', address: 'whatsapp:+15559876543' }],
+        },
+      ]);
+
+      const webhookPayload = {
+        eventType: 'COMMUNICATION_CREATED',
+        data: {
+          conversationId: 'CHtest123456789',
+          content: {
+            type: 'TEXT',
+            text: 'Hello',
+          },
+          author: {
+            address: 'whatsapp:+15559876543',
+            channel: 'WHATSAPP',
+          },
+        },
+      };
+
+      // Should not throw - error is handled gracefully
+      await expect(channelAlways.processWebhook(webhookPayload)).resolves.not.toThrow();
+
+      expect(retrieveMemorySpy).toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/whatsapp-channel.test.ts
+++ b/tests/whatsapp-channel.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WhatsAppChannel, TAC } from '@twilio/tac-core';
+import { createTestTAC } from './helpers/tac';
+
+describe('WhatsApp Channel', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const getTestConfig = () => ({
+    accountSid: 'ACtest123456789',
+    authToken: 'test_token_123',
+    apiKey: 'test_api_key',
+    apiSecret: 'test_api_token',
+    phoneNumber: '+15551234567',
+    whatsappNumber: 'whatsapp:+15551234567',
+    conversationConfigurationId: 'conv_configuration_01kbjqhn79f0fvwfsxqzd5nqhd',
+  });
+
+  let channel: WhatsAppChannel;
+  let tac: TAC;
+
+  beforeEach(async () => {
+    tac = await createTestTAC(getTestConfig());
+    channel = new WhatsAppChannel(tac);
+    // Short-circuit memory retrieval
+    vi.spyOn(tac, 'retrieveMemory').mockResolvedValue(undefined as never);
+    // Short-circuit reconcileParticipants
+    vi.spyOn(channel as any, 'reconcileParticipants').mockResolvedValue([
+      {
+        id: 'PA111',
+        conversationId: 'CHtest123456789',
+        accountId: 'ACtest123456789',
+        type: 'AI_AGENT',
+        addresses: [{ channel: 'WHATSAPP', address: 'whatsapp:+15551234567' }],
+      },
+      {
+        id: 'PA222',
+        conversationId: 'CHtest123456789',
+        accountId: 'ACtest123456789',
+        type: 'CUSTOMER',
+        addresses: [{ channel: 'WHATSAPP', address: 'whatsapp:+15559876543' }],
+      },
+    ]);
+  });
+
+  describe('initialization', () => {
+    it('should create WhatsApp channel with config', () => {
+      expect(channel).toBeInstanceOf(WhatsAppChannel);
+      expect(channel.channelType).toBe('whatsapp');
+    });
+
+    it('should start with no active conversations', () => {
+      expect(channel.isConversationActive('CHtest123456789')).toBe(false);
+    });
+
+    it('should throw error if whatsappNumber is not configured', async () => {
+      const configWithoutWhatsApp = {
+        accountSid: 'ACtest123456789',
+        authToken: 'test_token_123',
+        apiKey: 'test_api_key',
+        apiSecret: 'test_api_token',
+        phoneNumber: '+15551234567',
+        conversationConfigurationId: 'conv_configuration_01kbjqhn79f0fvwfsxqzd5nqhd',
+      };
+      const tacWithoutWhatsApp = await createTestTAC(configWithoutWhatsApp);
+      const whatsappChannel = new WhatsAppChannel(tacWithoutWhatsApp);
+
+      expect(() => (whatsappChannel as any).isDefaultAgentAddress('whatsapp:+15551234567')).toThrow(
+        'whatsappNumber is required for WhatsApp channel'
+      );
+    });
+
+    it('should default memoryMode to "never"', () => {
+      const defaultChannel = new WhatsAppChannel(tac);
+      expect((defaultChannel as any).memoryMode).toBe('never');
+    });
+
+    it('should accept memoryMode "always"', () => {
+      const alwaysChannel = new WhatsAppChannel(tac, { memoryMode: 'always' });
+      expect((alwaysChannel as any).memoryMode).toBe('always');
+    });
+
+    it('should accept memoryMode "never"', () => {
+      const neverChannel = new WhatsAppChannel(tac, { memoryMode: 'never' });
+      expect((neverChannel as any).memoryMode).toBe('never');
+    });
+
+    it('should reject invalid memoryMode', () => {
+      expect(() => new WhatsAppChannel(tac, { memoryMode: 'invalid' as any })).toThrow(
+        'Invalid memoryMode: "invalid". Must be "always" or "never".'
+      );
+    });
+  });
+
+  describe('webhook processing', () => {
+    it('should process COMMUNICATION_CREATED event', async () => {
+      const messageReceivedCallback = vi.fn();
+      channel.on('messageReceived', messageReceivedCallback);
+
+      const webhookPayload = {
+        eventType: 'COMMUNICATION_CREATED',
+        data: {
+          conversationId: 'CHtest123456789',
+          profileId: 'profile_id_123',
+          id: 'comm_id_123',
+          author: {
+            address: 'whatsapp:+15559876543',
+            channel: 'WHATSAPP',
+            participantId: 'PA222',
+          },
+          content: {
+            type: 'text',
+            text: 'Hello via WhatsApp',
+          },
+        },
+      };
+
+      await channel.processWebhook(webhookPayload);
+
+      expect(messageReceivedCallback).toHaveBeenCalledWith({
+        conversationId: 'CHtest123456789',
+        profileId: 'profile_id_123',
+        message: 'Hello via WhatsApp',
+        author: 'whatsapp:+15559876543',
+        userMemory: undefined,
+      });
+    });
+
+    it('should ignore messages from agent itself', async () => {
+      const messageReceivedCallback = vi.fn();
+      channel.on('messageReceived', messageReceivedCallback);
+
+      const webhookPayload = {
+        eventType: 'COMMUNICATION_CREATED',
+        data: {
+          conversationId: 'CHtest123456789',
+          author: {
+            address: 'whatsapp:+15551234567',
+            channel: 'WHATSAPP',
+          },
+          content: {
+            type: 'text',
+            text: 'Message from bot',
+          },
+        },
+      };
+
+      await channel.processWebhook(webhookPayload);
+
+      expect(messageReceivedCallback).not.toHaveBeenCalled();
+    });
+
+    it('should filter events not for WHATSAPP channel', async () => {
+      const messageReceivedCallback = vi.fn();
+      channel.on('messageReceived', messageReceivedCallback);
+
+      const webhookPayload = {
+        eventType: 'COMMUNICATION_CREATED',
+        data: {
+          conversationId: 'CHtest123456789',
+          author: {
+            address: '+15559876543',
+            channel: 'SMS',
+          },
+          content: {
+            type: 'text',
+            text: 'SMS message',
+          },
+        },
+      };
+
+      await channel.processWebhook(webhookPayload);
+
+      expect(messageReceivedCallback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendResponse', () => {
+    it('should throw error without reconciled session', async () => {
+      await expect(
+        channel.sendResponse('CHtest123456789', 'Hello')
+      ).rejects.toThrow(
+        'Unable to send WhatsApp: sendResponse called without a reconciled session'
+      );
+    });
+
+    it('should send WhatsApp message with reconciled session', async () => {
+      // Setup session with reconciled participants
+      const session = (channel as any).startConversation('CHtest123456789');
+      session.authorInfo = {
+        address: 'whatsapp:+15559876543',
+        participantId: 'PA222',
+      };
+      session.aiAgentInfo = {
+        address: 'whatsapp:+15551234567',
+        participantId: 'PA111',
+      };
+
+      const conversationClient = tac.getConversationClient();
+      const createActionSpy = vi.spyOn(conversationClient!, 'createAction').mockResolvedValue(undefined as never);
+
+      await channel.sendResponse('CHtest123456789', 'Hello from WhatsApp');
+
+      expect(createActionSpy).toHaveBeenCalledWith('CHtest123456789', {
+        type: 'SEND_MESSAGE',
+        payload: {
+          from: {
+            channel: 'WHATSAPP',
+            participantId: 'PA111',
+          },
+          to: [
+            {
+              channel: 'WHATSAPP',
+              participantId: 'PA222',
+            },
+          ],
+          content: { text: 'Hello from WhatsApp' },
+        },
+      });
+    });
+  });
+
+  describe('initiateOutboundConversation', () => {
+    it('should throw error if whatsappNumber is not configured', async () => {
+      const configWithoutWhatsApp = {
+        accountSid: 'ACtest123456789',
+        authToken: 'test_token_123',
+        apiKey: 'test_api_key',
+        apiSecret: 'test_api_token',
+        phoneNumber: '+15551234567',
+        conversationConfigurationId: 'conv_configuration_01kbjqhn79f0fvwfsxqzd5nqhd',
+      };
+      const tacWithoutWhatsApp = await createTestTAC(configWithoutWhatsApp);
+      const whatsappChannel = new WhatsAppChannel(tacWithoutWhatsApp);
+
+      await expect(
+        whatsappChannel.initiateOutboundConversation({
+          to: 'whatsapp:+15559876543',
+          message: 'Hello',
+        })
+      ).rejects.toThrow('whatsappNumber is required for WhatsApp channel');
+    });
+
+    it('should initiate outbound WhatsApp conversation', async () => {
+      const conversationClient = tac.getConversationClient();
+
+      vi.spyOn(conversationClient!, 'createOrReuseConversation').mockResolvedValue({
+        conversation: { id: 'CHoutbound123' },
+        reused: false,
+      } as any);
+
+      vi.spyOn(conversationClient!, 'listParticipants').mockResolvedValue([
+        {
+          id: 'PA111',
+          conversationId: 'CHoutbound123',
+          type: 'AI_AGENT',
+          addresses: [{ channel: 'WHATSAPP', address: 'whatsapp:+15551234567' }],
+        },
+        {
+          id: 'PA222',
+          conversationId: 'CHoutbound123',
+          type: 'CUSTOMER',
+          addresses: [{ channel: 'WHATSAPP', address: 'whatsapp:+15559876543' }],
+        },
+      ] as any);
+
+      const createActionSpy = vi.spyOn(conversationClient!, 'createAction').mockResolvedValue(undefined as never);
+
+      const result = await channel.initiateOutboundConversation({
+        to: 'whatsapp:+15559876543',
+        message: 'Hello from outbound WhatsApp',
+      });
+
+      expect(result.conversationId).toBe('CHoutbound123');
+      expect(result.session).toBeDefined();
+      expect(createActionSpy).toHaveBeenCalledWith('CHoutbound123', {
+        type: 'SEND_MESSAGE',
+        payload: {
+          from: { channel: 'WHATSAPP', participantId: 'PA111' },
+          to: [{ channel: 'WHATSAPP', participantId: 'PA222' }],
+          content: { text: 'Hello from outbound WhatsApp' },
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds full WhatsApp channel support with feature parity to SMS and Chat channels.

## Changes

### Core Implementation
- **WhatsAppChannel class** extending MessagingChannel with same patterns as SMS/Chat
- **Configuration**: Added `whatsappNumber` config with `TWILIO_WHATSAPP_NUMBER` env var
- **Format validation**: Zod regex validation for `whatsapp:+1234567890` format
- **Auto-discovery**: TACServer automatically discovers WhatsApp channel alongside SMS/Chat
- **Type system**: Added 'whatsapp' to ChannelType enum

### Profile Resolution Fix
- **Issue**: WhatsApp channel was excluded from profile resolution during reconciliation, preventing first-time WhatsApp users from accessing Memory API
- **Fix**: Added WHATSAPP to `resolveCustomerProfile()` channel check
- **Memory API**: Use native `whatsapp` identity type for profile lookups (preserves `whatsapp:` prefix)
- **Impact**: First-time WhatsApp users now get automatic profile creation and memory access

### Features
- ✅ Inbound WhatsApp message handling via webhooks
- ✅ Outbound conversations via `initiateOutboundConversation()`
- ✅ Message sending via Conversation Orchestrator Actions API
- ✅ Memory mode support ('always' / 'never') with profile resolution
- ✅ Full type safety with Zod validation
- ✅ PII protection (address masking in logs)

### Examples
- **New**: Simple WhatsApp example with OpenAI integration (`getting_started/examples/features/whatsapp/`)
  - Demonstrates basic text messaging with conversation history
  - Uses default TACServer config (port 3000) for simplicity
  - No memory mode configuration to keep example focused
- **Updated**: Outbound example now supports WhatsApp alongside SMS and Voice
- **Validation**: Outbound example validates `whatsapp:` prefix format with clear error messages
- **Documentation**: Updated all relevant docs, READMEs, and env var examples

### Tests
- **New**: 14 comprehensive WhatsApp channel tests covering initialization, webhooks, sendResponse, and outbound
- **New**: 3 memory retrieval tests for WhatsApp (memoryMode 'never', 'always', error handling)
- **Fixed**: 2 failing SMS channel memory retrieval tests (added missing mocks)
- **Status**: ✅ All 506 tests passing (1 skipped is pre-existing)

## Architecture

- **Webhook fan-out**: All messaging webhooks sent to all registered channels
- **Channel filtering**: Each channel filters by `author.channel` field
- **Profile resolution**: Uses Memory API's native `whatsapp` identity type
- **No breaking changes**: Purely additive implementation

## Commit History

1. **feat(core): Add WhatsApp channel support** - Core implementation with channel class, config, tests, and examples
2. **fix(core): Enable WhatsApp profile resolution during reconciliation** - Fix profile resolution bug preventing Memory API access for first-time users
3. **refactor(examples): Simplify WhatsApp example by removing memory mode** - Remove memory-related code to focus on basic messaging
4. **refactor(examples): Use default TACServer config in WhatsApp example** - Remove explicit server config boilerplate

## Test Plan

- [x] Unit tests passing (506/506)
- [x] TypeScript compilation successful
- [x] Build successful
- [x] Linting passing
- [x] Inbound WhatsApp conversations tested with live Twilio WhatsApp number
- [x] Outbound WhatsApp conversations tested with live Twilio WhatsApp number
- [x] Memory retrieval confirmed working
- [x] Profile resolution tested with Memory API
- [x] OpenAI integration confirmed working

## Validation

```bash
npm test           # ✅ 506 passed, 1 skipped (pre-existing)
npm run typecheck  # ✅ Success
npm run build      # ✅ Success
npm run lint       # ✅ Passing
```

## Breaking Changes

None. This is a purely additive change.

## Python SDK Parity

⚠️ **TypeScript now ahead of Python**: Python SDK has the same profile resolution limitation (only supports SMS/VOICE). TypeScript implementation now supports WhatsApp profile resolution that Python does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)