### PR TITLE
fix(tests): Stub reconcileParticipants on SMSChannel prototype

### DIFF
--- a/tests/sms-channel.test.ts
+++ b/tests/sms-channel.test.ts
@@ -31,8 +31,10 @@ describe('SMS Channel', () => {
     vi.spyOn(tac, 'retrieveMemory').mockResolvedValue(undefined as never);
     // Short-circuit reconcileParticipants so webhook processing tests don't
     // need to mock listParticipants. Tests that care about reconcile behavior
-    // should override this spy.
-    vi.spyOn(channel as any, 'reconcileParticipants').mockResolvedValue([
+    // should override this spy. Spy on the prototype so the stub applies to
+    // any SMSChannel instance created in a test (e.g. memoryMode tests that
+    // construct their own channel).
+    vi.spyOn(SMSChannel.prototype as any, 'reconcileParticipants').mockResolvedValue([
       {
         id: 'PA111',
         conversationId: 'CHtest123456789',


### PR DESCRIPTION
## Summary

Two SMS memoryMode tests were failing because the `reconcileParticipants` stub in `beforeEach` was attached to a single channel instance. The two failing tests construct their own `new SMSChannel(tac, { memoryMode: 'always' })`, so the stub didn't apply — `reconcileParticipants` hit the real code path, failed against the mocked Twilio API (401), returned `null`, and `handleCommunicationCreated` bailed out before reaching `retrieveMemoryIfEnabled`.

Moved the stub to `SMSChannel.prototype` so every instance constructed in a test picks it up.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

## SDK Parity

- [x] Change is TypeScript-specific (no Python update needed)
- [ ] Python SDK PR created:

🤖 Generated with [Claude Code](https://claude.com/claude-code)