### PR TITLE
fix(tests): Migrate RCS fanout test to flat TACServer port config

### DIFF
--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -506,7 +506,7 @@ describe('TACServer messaging channel auto-discovery', () => {
 
     server = new TACServer(tac, {
       development: true,
-      voice: { port: currentPort },
+      port: currentPort,
     });
 
     await server.start();


### PR DESCRIPTION
## Summary

The "fans a webhook out to a registered RCS channel when messagingChannels is omitted" test in \`tests/server.test.ts\` still used the nested \`voice: { port }\` shape that #30 flattened. With the nested shape, the \`port\` field is silently ignored — the server binds to the default port (8000), the test's \`fetch\` targets \`currentPort\`, and you get \`ECONNREFUSED\`.

#30 migrated every other test in this file to the new flat shape. This one was missed because it lives in a separate \`describe\` block that was added earlier in the RCS sync (#26), so it wasn't next to the bulk of the edits.

The failure wasn't a race or a flake — it was 100% reproducible once you looked closely. It just *looked* flaky because other describe blocks created servers on matching ports (e.g. 4000), so a reader scanning logs might assume the server was up.

## Test plan

- [x] \`npx vitest run tests/server.test.ts -t "fans a webhook out to a registered RCS"\` — passes
- [x] \`npx vitest run\` (full suite) — 526 passed, 1 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)