### PR TITLE
docs: Update installation instructions to reference npm package

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -280,7 +280,7 @@ ls -la getting_started/examples/openai/node_modules/@twilio/
 
 The SDK is published to npm as `twilio-agent-connect`.
 
-1. **Update versions** in package.json files
-2. **Build all packages**: `npm run build`
+1. **Update the version** in the root `package.json`
+2. **Build** from the repository root: `npm run build`
 3. **Run tests**: `npm test`
-4. **Publish**: `npm publish --workspaces`
+4. **Publish** from the repository root: `npm publish`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -276,13 +276,11 @@ ls -la getting_started/examples/openai/node_modules/@twilio/
 6. **Run linting and formatting before commits**
 7. **Write tests for new features**
 
-## Publishing (Future)
+## Publishing
 
-When ready to publish:
+The SDK is published to npm as `twilio-agent-connect`.
 
 1. **Update versions** in package.json files
 2. **Build all packages**: `npm run build`
 3. **Run tests**: `npm test`
 4. **Publish**: `npm publish --workspaces`
-
-Examples will continue to work with published versions by changing `*` to actual version numbers.

--- a/README.md
+++ b/README.md
@@ -43,24 +43,10 @@ Seamlessly integrate with Twilio's Memory Store and Conversation Orchestrator to
 
 ## Get Started
 
-To get started, set up your Node.js environment (Node.js 22.13.0 or newer required), and then install TAC SDK package.
-
-> [!IMPORTANT]
-> TAC packages are not yet published to npm. We recommend building your agent directly in this repository.
-
-### Build in This Repository
-
-Clone this repository and work within it:
+To get started, set up your Node.js environment (Node.js 22.13.0 or newer required), and then install the [TAC SDK package](https://www.npmjs.com/package/twilio-agent-connect):
 
 ```bash
-git clone https://github.com/twilio/twilio-agent-connect-typescript.git
-cd twilio-agent-connect-typescript
-
-# Install dependencies
-npm install
-
-# Build packages
-npm run build
+npm install twilio-agent-connect
 ```
 
 ## Quick Examples
@@ -87,15 +73,15 @@ After completing setup, here's a minimal example to get started:
 
 Use the OpenAI SDK to build an AI agent that works across Voice and SMS channels with conversation memory and user context.
 
-First, install the required dependencies in the repository:
+First, install the required dependencies:
 
 ```bash
-npm install openai dotenv
+npm install twilio-agent-connect openai dotenv
 ```
 
 > **Note**: `dotenv` is optional — TAC works with environment variables from any source (`.env` files, Docker, Kubernetes, CI/CD, shell exports, etc.).
 
-Then create your application (e.g., in `getting_started/examples/` or your own directory):
+Then create your application:
 
 ```typescript
 import { config } from 'dotenv';


### PR DESCRIPTION
## Summary

The SDK is now published to npm as `twilio-agent-connect`. This PR updates the README and DEVELOPMENT.md to:
- Replace the git clone-based installation with `npm install twilio-agent-connect`
- Remove the "not yet published to npm" callout
- Add a link to the npm package page
- Update the "Publishing (Future)" section to reflect current state

## Type of Change

- [x] Documentation update

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated
- [ ] Tested E2E

## SDK Parity

This is the **TypeScript SDK**. If this change affects shared functionality, ensure the [Python SDK](https://github.com/twilio/twilio-agent-connect-python) is updated as well.

- [x] Change is TypeScript-specific (no Python update needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)