### PR TITLE
refactor(chat): remove chatService workaround; scope TACServer sig validation to TAC routes

### DIFF
--- a/getting_started/examples/chat/src/index.ts
+++ b/getting_started/examples/chat/src/index.ts
@@ -17,14 +17,15 @@
 
 import { config } from 'dotenv';
 import { Agent, AgentInputItem, run, setTracingDisabled } from '@openai/agents';
-import Fastify from 'fastify';
 import fastifyStatic from '@fastify/static';
+import type { FastifyRequest, FastifyReply } from 'fastify';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import Twilio from 'twilio';
 import {
   TAC,
   TACConfig,
+  TACServer,
   ChatChannel,
   ConversationSession,
   TACMemoryResponse,
@@ -116,27 +117,17 @@ tac.onConversationEnded(({ session }) => {
   delete conversationHistory[session.conversationId];
 });
 
-// Get __dirname equivalent for ESM
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const server = new TACServer(tac);
 
-// Create Fastify server
-const app = Fastify({
-  logger: {
-    level: 'info',
-  },
-});
-
-// Serve static files
-await app.register(fastifyStatic, {
+// Layer the chat UI routes onto the same Fastify instance TAC provides.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+await server.fastify.register(fastifyStatic, {
   root: path.join(__dirname, '..', 'public'),
   prefix: '/',
 });
 
-// Token endpoint for Conversations SDK
-app.post('/token', async (request, reply) => {
+server.fastify.post('/token', async (request: FastifyRequest, reply: FastifyReply) => {
   const { identity } = request.body as { identity: string };
-
   if (!identity) {
     await reply.code(400).send({ error: 'Identity is required' });
     return;
@@ -146,55 +137,14 @@ app.post('/token', async (request, reply) => {
   const apiKey = process.env.TWILIO_API_KEY;
   const apiSecret = process.env.TWILIO_API_SECRET;
   const serviceSid = process.env.TWILIO_CONVERSATIONS_SERVICE_SID;
-
   if (!accountSid || !apiKey || !apiSecret || !serviceSid) {
-    app.log.error('Missing required credentials for token generation');
     await reply.code(500).send({ error: 'Missing Twilio credentials' });
     return;
   }
 
-  const AccessToken = Twilio.jwt.AccessToken;
-  const ChatGrant = AccessToken.ChatGrant;
-
-  const token = new AccessToken(accountSid, apiKey, apiSecret, { identity, ttl: 3600 });
-  const chatGrant = new ChatGrant({ serviceSid });
-  token.addGrant(chatGrant);
-
+  const token = new Twilio.jwt.AccessToken(accountSid, apiKey, apiSecret, { identity, ttl: 3600 });
+  token.addGrant(new Twilio.jwt.AccessToken.ChatGrant({ serviceSid }));
   await reply.send({ token: token.toJwt() });
 });
 
-// Conversation Orchestrator webhook handler
-app.post('/webhook', async (request, reply) => {
-  try {
-    const payload = request.body as Record<string, unknown> | undefined;
-    const data = payload?.data as Record<string, unknown> | undefined;
-    app.log.info(
-      {
-        eventType: payload?.eventType,
-        conversationId: data?.conversationId,
-        author: data?.author,
-      },
-      '/webhook received'
-    );
-    // Fire-and-forget webhook processing
-    chatChannel.processWebhook(request.body).catch((err: unknown) => {
-      app.log.error({ err }, 'Error processing chat webhook');
-    });
-    await reply.send({ status: 'ok' });
-  } catch (error) {
-    app.log.error({ error }, 'Error handling chat webhook');
-    await reply.code(400).send({ status: 'error', message: String(error) });
-  }
-});
-
-// Start the server
-app
-  .listen({ host: '0.0.0.0', port: 8000 })
-  .then(() => {
-    console.log('TAC Chat Server started on http://0.0.0.0:8000');
-    console.log('Open http://localhost:8000 in your browser to test chat');
-  })
-  .catch(error => {
-    console.error('Failed to start server:', error);
-    process.exit(1);
-  });
+await server.start();

--- a/getting_started/examples/chat/src/index.ts
+++ b/getting_started/examples/chat/src/index.ts
@@ -40,61 +40,25 @@ setTracingDisabled(true);
 
 const CHAT_IDENTITY = 'ai-agent';
 
-/**
- * Fail fast if the Conversation Orchestrator configuration has no classic
- * Conversations (V1) service attached.
- *
- * This check is example-level setup validation, not part of the chat
- * integration. The TAC SDK does not require this — but the V1 Chat backend
- * this example uses does, and misconfiguration surfaces as cryptic failures
- * on the first inbound message. Enable it in the Twilio Console under
- * Conversation Orchestrator -> Conversation Configuration -> Channel traffic
- * -> "+ Add messaging & chat traffic", which attaches a classic Conversations
- * service to the configuration.
- */
-async function assertChatTrafficConfigured(): Promise<void> {
-  const configurationId = process.env.TWILIO_CONVERSATION_CONFIGURATION_ID;
-  const apiKey = process.env.TWILIO_API_KEY;
-  const apiSecret = process.env.TWILIO_API_SECRET;
-  if (!configurationId || !apiKey || !apiSecret) {
-    return; // Let TAC's own credential checks surface the error.
-  }
-
-  const url = `https://conversations.twilio.com/v2/ControlPlane/Configurations/${configurationId}`;
-  const authHeader = 'Basic ' + Buffer.from(`${apiKey}:${apiSecret}`).toString('base64');
-
-  let configJson: Record<string, unknown>;
-  try {
-    const response = await fetch(url, { headers: { Authorization: authHeader } });
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-    configJson = (await response.json()) as Record<string, unknown>;
-  } catch (err) {
-    console.warn(
-      'Could not verify CO configuration has classic Conversations attached; ' +
-        'skipping chat-traffic check:',
-      err
-    );
-    return;
-  }
-
-  const v1Bridge = (configJson.conversationsV1Bridge ?? {}) as { serviceId?: string };
-  if (!v1Bridge.serviceId) {
-    console.error(
-      `\nError: Conversation Orchestrator configuration '${configurationId}' ` +
-        'has no classic Conversations (V1) service attached — the chat example ' +
-        'requires one.\n\n' +
-        'To enable it: Twilio Console -> Conversation Orchestrator -> ' +
-        'Conversation Configuration -> Channel traffic -> ' +
-        '"+ Add messaging & chat traffic". Attach a classic Conversations ' +
-        'service that has Chat enabled.\n'
-    );
-    process.exit(1);
-  }
+// Example-level setup check (not required by the SDK): the V1 Chat backend behind
+// this example needs a classic Conversations service attached to the CO
+// configuration. Enable it in Console → Conversation Orchestrator →
+// Conversation Configuration → Channel traffic → "+ Add messaging & chat traffic".
+const configurationId = process.env.TWILIO_CONVERSATION_CONFIGURATION_ID!;
+const auth = Buffer.from(`${process.env.TWILIO_API_KEY}:${process.env.TWILIO_API_SECRET}`).toString('base64');
+const coConfig = await (
+  await fetch(`https://conversations.twilio.com/v2/ControlPlane/Configurations/${configurationId}`, {
+    headers: { Authorization: `Basic ${auth}` },
+  })
+).json() as { conversationsV1Bridge?: { serviceId?: string } | null };
+if (!coConfig.conversationsV1Bridge?.serviceId) {
+  console.error(
+    `Configuration '${configurationId}' has no classic Conversations service attached. ` +
+      'Enable it in Console → Conversation Orchestrator → Conversation Configuration → ' +
+      'Channel traffic → "+ Add messaging & chat traffic".'
+  );
+  process.exit(1);
 }
-
-await assertChatTrafficConfigured();
 
 const tac = await TAC.create({ config: TACConfig.fromEnv() });
 const chatChannel = new ChatChannel(tac, { agentAddress: CHAT_IDENTITY });

--- a/getting_started/examples/chat/src/index.ts
+++ b/getting_started/examples/chat/src/index.ts
@@ -40,6 +40,62 @@ setTracingDisabled(true);
 
 const CHAT_IDENTITY = 'ai-agent';
 
+/**
+ * Fail fast if the Conversation Orchestrator configuration has no classic
+ * Conversations (V1) service attached.
+ *
+ * This check is example-level setup validation, not part of the chat
+ * integration. The TAC SDK does not require this — but the V1 Chat backend
+ * this example uses does, and misconfiguration surfaces as cryptic failures
+ * on the first inbound message. Enable it in the Twilio Console under
+ * Conversation Orchestrator -> Conversation Configuration -> Channel traffic
+ * -> "+ Add messaging & chat traffic", which attaches a classic Conversations
+ * service to the configuration.
+ */
+async function assertChatTrafficConfigured(): Promise<void> {
+  const configurationId = process.env.TWILIO_CONVERSATION_CONFIGURATION_ID;
+  const apiKey = process.env.TWILIO_API_KEY;
+  const apiSecret = process.env.TWILIO_API_SECRET;
+  if (!configurationId || !apiKey || !apiSecret) {
+    return; // Let TAC's own credential checks surface the error.
+  }
+
+  const url = `https://conversations.twilio.com/v2/ControlPlane/Configurations/${configurationId}`;
+  const authHeader = 'Basic ' + Buffer.from(`${apiKey}:${apiSecret}`).toString('base64');
+
+  let configJson: Record<string, unknown>;
+  try {
+    const response = await fetch(url, { headers: { Authorization: authHeader } });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    configJson = (await response.json()) as Record<string, unknown>;
+  } catch (err) {
+    console.warn(
+      'Could not verify CO configuration has classic Conversations attached; ' +
+        'skipping chat-traffic check:',
+      err
+    );
+    return;
+  }
+
+  const v1Bridge = (configJson.conversationsV1Bridge ?? {}) as { serviceId?: string };
+  if (!v1Bridge.serviceId) {
+    console.error(
+      `\nError: Conversation Orchestrator configuration '${configurationId}' ` +
+        'has no classic Conversations (V1) service attached — the chat example ' +
+        'requires one.\n\n' +
+        'To enable it: Twilio Console -> Conversation Orchestrator -> ' +
+        'Conversation Configuration -> Channel traffic -> ' +
+        '"+ Add messaging & chat traffic". Attach a classic Conversations ' +
+        'service that has Chat enabled.\n'
+    );
+    process.exit(1);
+  }
+}
+
+await assertChatTrafficConfigured();
+
 const tac = await TAC.create({ config: TACConfig.fromEnv() });
 const chatChannel = new ChatChannel(tac, { agentAddress: CHAT_IDENTITY });
 

--- a/getting_started/examples/chat/src/index.ts
+++ b/getting_started/examples/chat/src/index.ts
@@ -41,9 +41,8 @@ setTracingDisabled(true);
 const CHAT_IDENTITY = 'ai-agent';
 
 // Example-level setup check (not required by the SDK): the V1 Chat backend behind
-// this example needs a classic Conversations service attached to the CO
-// configuration. Enable it in Console → Conversation Orchestrator →
-// Conversation Configuration → Channel traffic → "+ Add messaging & chat traffic".
+// this example needs a classic Conversations service — with Chat enabled on it —
+// attached to the CO configuration.
 const configurationId = process.env.TWILIO_CONVERSATION_CONFIGURATION_ID!;
 const auth = Buffer.from(`${process.env.TWILIO_API_KEY}:${process.env.TWILIO_API_SECRET}`).toString('base64');
 const coConfig = await (
@@ -54,8 +53,8 @@ const coConfig = await (
 if (!coConfig.conversationsV1Bridge?.serviceId) {
   console.error(
     `Configuration '${configurationId}' has no classic Conversations service attached. ` +
-      'Enable it in Console → Conversation Orchestrator → Conversation Configuration → ' +
-      'Channel traffic → "+ Add messaging & chat traffic".'
+      'Attach one (with Chat enabled) via Console → Conversation Orchestrator → ' +
+      'Conversation Configuration → Channel traffic → "+ Add messaging & chat traffic".'
   );
   process.exit(1);
 }

--- a/getting_started/examples/chat/src/index.ts
+++ b/getting_started/examples/chat/src/index.ts
@@ -45,12 +45,17 @@ const CHAT_IDENTITY = 'ai-agent';
 // this example needs a classic Conversations service — with Chat enabled on it —
 // attached to the CO configuration.
 const configurationId = process.env.TWILIO_CONVERSATION_CONFIGURATION_ID!;
-const auth = Buffer.from(`${process.env.TWILIO_API_KEY}:${process.env.TWILIO_API_SECRET}`).toString('base64');
-const coConfig = await (
-  await fetch(`https://conversations.twilio.com/v2/ControlPlane/Configurations/${configurationId}`, {
-    headers: { Authorization: `Basic ${auth}` },
-  })
-).json() as { conversationsV1Bridge?: { serviceId?: string } | null };
+const auth = Buffer.from(`${process.env.TWILIO_API_KEY}:${process.env.TWILIO_API_SECRET}`).toString(
+  'base64'
+);
+const coConfig = (await (
+  await fetch(
+    `https://conversations.twilio.com/v2/ControlPlane/Configurations/${configurationId}`,
+    {
+      headers: { Authorization: `Basic ${auth}` },
+    }
+  )
+).json()) as { conversationsV1Bridge?: { serviceId?: string } | null };
 if (!coConfig.conversationsV1Bridge?.serviceId) {
   console.error(
     `Configuration '${configurationId}' has no classic Conversations service attached. ` +

--- a/packages/core/src/channels/chat.ts
+++ b/packages/core/src/channels/chat.ts
@@ -133,14 +133,8 @@ export class ChatChannel extends MessagingChannel {
         );
       }
 
-      // TODO(conv-orch): Drop `chatService` here once the Actions API resolves
-      // the V1 Chat service SID server-side. Confirmed this should not be
-      // required client-side; keep the workaround until the server-side fix
-      // ships. `channelId` stays — it's a permanent per-conversation requirement.
-      const chatServiceSid = this.tac.conversationsV1ServiceSid;
       const channelSettings: ActionChannelSettings = {
         channelId: chatChannelSid,
-        ...(chatServiceSid ? { chatService: chatServiceSid } : {}),
       };
 
       this.logger.debug(
@@ -205,8 +199,6 @@ export class ChatChannel extends MessagingChannel {
       'Initiating outbound chat conversation'
     );
 
-    const chatServiceSid = this.tac.conversationsV1ServiceSid;
-
     return this.initiateOutboundMessagingConversation({
       channel: 'CHAT',
       to: validated.to,
@@ -216,7 +208,6 @@ export class ChatChannel extends MessagingChannel {
       channelId: validated.channelId,
       channelSettings: {
         channelId: validated.channelId,
-        ...(chatServiceSid ? { chatService: chatServiceSid } : {}),
       },
     });
   }

--- a/packages/core/src/lib/tac.ts
+++ b/packages/core/src/lib/tac.ts
@@ -66,21 +66,6 @@ export class TAC {
 
   private memoryStoreId: string | undefined;
 
-  /**
-   * V1 Conversations service SID sourced from `conversationsV1Bridge.serviceId`
-   * on the configuration. Forwarded by the chat channel as
-   * `channelSettings.chatService` on Actions API requests.
-   *
-   * TODO(conv-orch): Remove once the Actions API resolves the V1 Chat service SID
-   * server-side. Confirmed this should not be required client-side; until the
-   * server-side fix ships, CHAT sends fail with
-   *   "chatService attribute is required for CHAT channel"
-   * unless we pass it on channelSettings.chatService. When the server-side fix
-   * lands, drop this attribute plus ActionChannelSettings.chatService and the
-   * chat channel's chatServiceSid plumbing.
-   */
-  public conversationsV1ServiceSid: string | undefined;
-
   // Callback registrations
   private messageReadyCallback?: MessageReadyCallback;
   private interruptCallback?: InterruptCallback;
@@ -128,10 +113,6 @@ export class TAC {
       );
 
       tac.memoryStoreId = conversationConfig.memoryStoreId;
-      // TODO(conv-orch): Remove once the Actions API resolves the V1 Chat service SID
-      // server-side — see the conversationsV1ServiceSid field comment above.
-      tac.conversationsV1ServiceSid =
-        conversationConfig.conversationsV1Bridge?.serviceId ?? undefined;
       tac.memoryClient = new MemoryClient(
         tac.config,
         conversationConfig.memoryStoreId,

--- a/packages/core/src/types/conversation.ts
+++ b/packages/core/src/types/conversation.ts
@@ -146,10 +146,6 @@ export type ActionTextContent = z.infer<typeof ActionTextContentSchema>;
  */
 export const ActionChannelSettingsSchema = z.looseObject({
   channelId: z.string().optional(),
-  // TODO(conv-orch): Drop `chatService` once the Actions API resolves the V1 Chat
-  // service SID server-side. Confirmed this should not be required client-side;
-  // keep the field until the server-side fix ships.
-  chatService: z.string().optional(),
 });
 
 export type ActionChannelSettings = z.infer<typeof ActionChannelSettingsSchema>;
@@ -385,20 +381,6 @@ export const ConversationGroupingTypeSchema = z.enum([
 export type ConversationGroupingType = z.infer<typeof ConversationGroupingTypeSchema>;
 
 /**
- * Conversations V1 bridge settings on a ConversationConfiguration.
- *
- * TODO(conv-orch): Remove this schema once the Actions API resolves the V1 Chat
- * service SID server-side. Currently used to extract `conversationsV1Bridge.serviceId`
- * from the Configuration so the chat channel can forward it as
- * channelSettings.chatService — drop together with the other TODO(conv-orch) sites.
- */
-export const ConversationsV1BridgeSchema = z.object({
-  serviceId: z.string(),
-});
-
-export type ConversationsV1Bridge = z.infer<typeof ConversationsV1BridgeSchema>;
-
-/**
  * Configuration settings for a conversation
  */
 export const ConversationConfigurationSchema = z.object({
@@ -417,9 +399,6 @@ export const ConversationConfigurationSchema = z.object({
   channelSettings: z.record(z.string(), ChannelSettingsSchema).nullable().optional(),
   statusCallbacks: z.array(StatusCallbackSchema).max(20).nullable().optional(),
   intelligenceConfigurationIds: z.array(z.string()).max(5).nullable().optional(),
-  // TODO(conv-orch): Drop this field once the Actions API resolves the V1 Chat
-  // service SID server-side — see ConversationsV1BridgeSchema above.
-  conversationsV1Bridge: ConversationsV1BridgeSchema.nullish(),
   createdAt: z.string().nullable().optional(),
   updatedAt: z.string().nullable().optional(),
   version: z.number().int().nullable().optional(),

--- a/packages/server/src/lib/server.ts
+++ b/packages/server/src/lib/server.ts
@@ -185,15 +185,16 @@ export class TACServer {
   }
 
   /**
-   * Validate the Twilio signature on an HTTP request. Returns `true` if valid;
-   * on failure sends a 403 reply and returns `false`. Scoped to TAC-registered
+   * Validate the Twilio signature on an HTTP request. On failure, sends a 403
+   * reply (Fastify halts the request once `reply.send` is called in a
+   * `preHandler`, so the route handler won't run). Scoped to TAC-registered
    * webhook routes — does not run on user-added routes registered on
    * `server.fastify`.
    */
   private async validateRequestSignature(
     request: FastifyRequest,
     reply: FastifyReply
-  ): Promise<boolean> {
+  ): Promise<void> {
     const signature = request.headers['x-twilio-signature'] as string;
     const url = this.getWebhookUrl(request);
     const authToken = this.tac.getConfig().authToken;
@@ -210,9 +211,7 @@ export class TACServer {
     if (!isValid) {
       this.fastify.log.warn({ url, hasSignature: !!signature }, 'Invalid Twilio webhook signature');
       await reply.code(403).send({ error: 'Invalid webhook signature' });
-      return false;
     }
-    return true;
   }
 
   /**

--- a/packages/server/src/lib/server.ts
+++ b/packages/server/src/lib/server.ts
@@ -208,10 +208,7 @@ export class TACServer {
     }
 
     if (!isValid) {
-      this.fastify.log.warn(
-        { url, hasSignature: !!signature },
-        'Invalid Twilio webhook signature'
-      );
+      this.fastify.log.warn({ url, hasSignature: !!signature }, 'Invalid Twilio webhook signature');
       await reply.code(403).send({ error: 'Invalid webhook signature' });
       return false;
     }

--- a/packages/server/src/lib/server.ts
+++ b/packages/server/src/lib/server.ts
@@ -185,54 +185,54 @@ export class TACServer {
   }
 
   /**
-   * Register global Twilio webhook signature validation hook
+   * Validate the Twilio signature on an HTTP request. Returns `true` if valid;
+   * on failure sends a 403 reply and returns `false`. Scoped to TAC-registered
+   * webhook routes — does not run on user-added routes registered on
+   * `server.fastify`.
    */
-  private registerWebhookValidation(): void {
-    this.fastify.addHook('preHandler', (request, reply, done): void => {
-      // Skip GET requests — WebSocket upgrades are validated in the route handler
-      if (request.method === 'GET') {
-        done();
-        return;
-      }
+  private async validateRequestSignature(
+    request: FastifyRequest,
+    reply: FastifyReply
+  ): Promise<boolean> {
+    const signature = request.headers['x-twilio-signature'] as string;
+    const url = this.getWebhookUrl(request);
+    const authToken = this.tac.getConfig().authToken;
 
-      const signature = request.headers['x-twilio-signature'] as string;
-      const url = this.getWebhookUrl(request);
-      const authToken = this.tac.getConfig().authToken;
+    let isValid: boolean;
+    if (request.url.includes('bodySHA256=')) {
+      const body = (request as FastifyRequest & { rawBody?: string }).rawBody ?? '';
+      isValid = twilio.validateRequestWithBody(authToken, signature, url, body);
+    } else {
+      const params = (request.body as Record<string, string>) || {};
+      isValid = twilio.validateRequest(authToken, signature, url, params);
+    }
 
-      let isValid: boolean;
-
-      // Check if this is a JSON body webhook (has bodySHA256 in query string)
-      if (request.url.includes('bodySHA256=')) {
-        const body = (request as FastifyRequest & { rawBody?: string }).rawBody ?? '';
-        isValid = twilio.validateRequestWithBody(authToken, signature, url, body);
-      } else {
-        // Form-encoded validation - use parsed params
-        const params = (request.body as Record<string, string>) || {};
-        isValid = twilio.validateRequest(authToken, signature, url, params);
-      }
-
-      if (!isValid) {
-        this.fastify.log.warn(
-          { url, hasSignature: !!signature },
-          'Invalid Twilio webhook signature'
-        );
-        void reply.code(403).send({ error: 'Invalid webhook signature' });
-        done();
-        return;
-      }
-
-      done();
-    });
+    if (!isValid) {
+      this.fastify.log.warn(
+        { url, hasSignature: !!signature },
+        'Invalid Twilio webhook signature'
+      );
+      await reply.code(403).send({ error: 'Invalid webhook signature' });
+      return false;
+    }
+    return true;
   }
 
   /**
    * Setup routes
    */
   private async setupRoutes(): Promise<void> {
+    const validateSignature = {
+      preHandler: async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
+        await this.validateRequestSignature(request, reply);
+      },
+    };
+
     // Messaging webhook — fan out to all enabled messaging channels (each self-filters)
     if (this.messagingChannels.length > 0) {
       this.fastify.post(
         this.config.webhookPaths.messaging || '/webhook',
+        validateSignature,
         async (request: FastifyRequest, reply: FastifyReply) => {
           const rawHeader = request.headers['i-twilio-idempotency-token'];
           const idempotencyToken = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
@@ -252,6 +252,7 @@ export class TACServer {
     // Voice webhook (POST - Twilio calls this when an incoming call arrives)
     this.fastify.post(
       this.config.webhookPaths.twiml || '/twiml',
+      validateSignature,
       async (request: FastifyRequest, reply: FastifyReply) => {
         try {
           if (!this.voiceChannel) {
@@ -301,6 +302,7 @@ export class TACServer {
     // ConversationRelay callback endpoint
     this.fastify.post(
       this.config.webhookPaths.conversationRelayCallback || '/conversation-relay-callback',
+      validateSignature,
       async (request: FastifyRequest, reply: FastifyReply) => {
         try {
           if (!this.voiceChannel) {
@@ -387,6 +389,7 @@ export class TACServer {
     if (this.config.webhookPaths.cintel) {
       this.fastify.post(
         this.config.webhookPaths.cintel,
+        validateSignature,
         async (request: FastifyRequest, reply: FastifyReply) => {
           if (!this.tac.isCintelEnabled()) {
             await reply.code(400).send({
@@ -461,10 +464,10 @@ export class TACServer {
         }
       );
 
-      // Register webhook signature validation (must be after formbody for body access)
-      this.registerWebhookValidation();
-
       // Set up routes (must be after plugin registration)
+      // Signature validation is applied per-route as a `preHandler` so it only
+      // runs on TAC-registered webhook routes, not on user-added routes on
+      // `server.fastify`.
       await this.setupRoutes();
 
       // Configure graceful shutdown to wait for WebSocket connections

--- a/tests/chat-channel.test.ts
+++ b/tests/chat-channel.test.ts
@@ -333,25 +333,6 @@ describe('Chat Channel', () => {
       );
     });
 
-    it('should forward chatService from TAC.conversationsV1ServiceSid when set', async () => {
-      // TODO(conv-orch): Drop this test when the chatService workaround is removed.
-      tac.conversationsV1ServiceSid = 'ISabcdef1234567890abcdef1234567890';
-
-      seedReconciledSession('CHtest123456789', {
-        channelId: 'CH00000000000000000000000000000000',
-      });
-
-      await channel.sendResponse('CHtest123456789', 'Hello');
-
-      const body = JSON.parse(mockAdapter.history.post[0]!.data);
-      expect(body.payload.channelSettings.chatService).toBe(
-        'ISabcdef1234567890abcdef1234567890'
-      );
-      expect(body.payload.channelSettings.channelId).toBe(
-        'CH00000000000000000000000000000000'
-      );
-    });
-
     it('should throw when channelId missing from session metadata', async () => {
       // Seed a reconciled session but without channelId
       seedReconciledSession('CHtest123456789');

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -116,6 +116,33 @@ describe('TACServer Webhook Validation', () => {
     expect(response.status).not.toBe(403);
   });
 
+  it('should not validate signatures on user-added routes', async () => {
+    // Regression test: signature validation should be scoped to TAC-registered
+    // webhook routes and not apply to custom routes registered on
+    // `server.fastify`. Previously a global preHandler 403'd any non-webhook
+    // POST route that lacked an X-Twilio-Signature header.
+    mockValidateRequest.mockReturnValue(false);
+
+    server = new TACServer(tac, {
+      development: true,
+      port: currentPort,
+    });
+
+    server.fastify.post('/custom', async () => ({ hello: 'world' }));
+
+    await server.start();
+
+    const response = await fetch(`http://localhost:${currentPort}/custom`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ anything: 'at all' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ hello: 'world' });
+    expect(mockValidateRequest).not.toHaveBeenCalled();
+  });
+
   it('should call validateRequest with correct parameters', async () => {
     mockValidateRequest.mockReturnValue(true);
 


### PR DESCRIPTION
## Summary

- **SDK:** Removed the `chatService`/`conversationsV1Bridge` workaround — CO now resolves the V1 Chat service SID server-side. Drops `ConversationsV1BridgeSchema`, `ActionChannelSettingsSchema.chatService`, `TAC.conversationsV1ServiceSid`, and all call-site plumbing. TAC no longer knows about the V1 bridge.
- **TACServer fix:** Scoped Twilio signature validation from a global Fastify `preHandler` to per-route `preHandler`s on the four TAC-registered webhook routes. Previously any user-added POST route on `server.fastify` got 403'd because it lacked `X-Twilio-Signature` — effectively unusable customization surface. Added a regression test.
- **Chat example:** Added a startup check that fails fast with Console guidance when the CO configuration has no classic Conversations service attached.
- **Chat example:** Migrated to `TACServer`, matching the other messaging examples. ~50 lines of boilerplate dropped. (Only safe after the sig-validation scoping fix — the custom `/token` POST would have been 403'd otherwise.)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring

## Checklist

- [x] Tests added/updated — dropped `chatService` forwarding test, added a regression test for the sig-validation scoping fix. 36 server tests + 18 chat-channel tests pass; no new typecheck errors vs. `main`.
- [ ] Documentation updated — no doc mentions of this workaround existed.
- [x] Tested E2E — inbound chat → agent reply round-tripped against a V1-bridged CO configuration. Chat example migrated to `TACServer` also verified live.

## SDK Parity

- [ ] Change is TypeScript-specific (no Python update needed)
- [x] Python SDK PR: twilio/twilio-agent-connect-python#41

The sig-validation scoping fix is TS-only — the Python server never had this issue because FastAPI dependencies are per-route, not global.

🤖 Generated with [Claude Code](https://claude.com/claude-code)