### PR TITLE
Remove registry-url from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
       - run: npm ci
 
       - name: Validate tag format and version match


### PR DESCRIPTION
Removed registry-url from setup-node action.

CI is failing to publish to NPM: https://github.com/twilio/twilio-agent-connect-typescript/actions/runs/25518418830/job/75052755392

Claude pointed out:
> The `actions/setup-node` with `registry-url` writes an `.npmrc` that expects `NODE_AUTH_TOKEN` to be set. If there's no actual token, `setup-node` may still write an empty or placeholder `authToken` line. For OIDC trusted publishing, `npm publish --provenance` should handle the auth exchange itself — but if the `.npmrc` has an `_authToken= line` (even empty), npm might use that instead of triggering the OIDC exchange.

This is an attempt to prevent that file from being written in case it is writing an invalid/empty `NODE_AUTH_TOKEN`