### PR TITLE
Revert "Remove registry-url from release workflow"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
+          registry-url: https://registry.npmjs.org
       - run: npm ci
 
       - name: Validate tag format and version match


### PR DESCRIPTION
Reverts twilio/twilio-agent-connect-typescript#42

Removing `registry-url` didn't work, now there's a new error earlier in the publishing step: https://github.com/twilio/twilio-agent-connect-typescript/actions/runs/25571392295/job/75067870488