### PR TITLE
ci: Use Node 24 for npm OIDC trusted publisher support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         node: [22, 24]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node }}
           cache: npm
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # https://docs.npmjs.com/trusted-publishers — never cache in release builds
       # Node 24+ required for npm OIDC trusted publisher support (npm >= 11.5.1)
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # https://docs.npmjs.com/trusted-publishers — never cache in release builds
+      # Node 24+ required for npm OIDC trusted publisher support (npm >= 11.5.1)
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22
+          node-version: 24
       - run: npm ci
 
       - name: Validate tag format and version match


### PR DESCRIPTION
## Summary

- Bump Node version in the release deploy job from 22 to 24
- Bump `actions/setup-node` from v4 to v6

npm OIDC trusted publisher requires npm >= 11.5.1, which ships with Node 24. Node 22 ships with npm 10.x which doesn't support the OIDC token exchange, causing E404 on publish.

## Type of Change

- [x] Bug fix

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated
- [ ] Tested E2E

## SDK Parity

- [x] Change is TypeScript-specific (no Python update needed)