### PR TITLE
Add voice channel webhook processing for conversation cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ The `TACServer` class (`packages/server/src/lib/server.ts`) provides a productio
   host: '0.0.0.0',
   port: 8000,
   webhookPaths: {
-    sms: '/webhook',
+    conversation: '/webhook',
     twiml: '/twiml',
     ws: '/ws',
     conversationRelayCallback: '/conversation-relay-callback',

--- a/packages/core/src/channels/base.ts
+++ b/packages/core/src/channels/base.ts
@@ -312,6 +312,58 @@ export abstract class BaseChannel {
   }
 
   /**
+   * Preprocess webhook before handling event-specific logic.
+   * Handles deduplication, validation, filtering, and data extraction.
+   *
+   * @param payload - Raw webhook payload from Twilio
+   * @param idempotencyToken - Optional idempotency token for deduplication
+   * @returns Preprocessed webhook data, or null if webhook should be skipped
+   */
+  protected preprocessWebhook(
+    payload: unknown,
+    idempotencyToken: string | undefined
+  ): {
+    webhookData: ConversationWebhookPayload;
+    eventType: string;
+    conversationId: string | undefined;
+  } | null {
+    this.logger.debug({ operation: 'webhook_processing' }, 'Processing webhook');
+
+    if (idempotencyToken && this.isDuplicateWebhook(idempotencyToken)) {
+      this.logger.debug({ idempotency_token: idempotencyToken }, 'Skipping duplicate webhook');
+      return null;
+    }
+
+    if (!this.validateWebhookPayload(payload)) {
+      throw new Error('Invalid webhook payload');
+    }
+
+    const webhookData = payload as ConversationWebhookPayload;
+    const eventType = webhookData.eventType;
+    const conversationId = webhookData.data?.conversationId || webhookData.data?.id;
+
+    // Self-filter: ignore events meant for other channel types
+    if (!this.isEventForThisChannel(webhookData)) {
+      this.logger.debug(
+        { event_type: eventType, channel: this.channelType, conversation_id: conversationId },
+        'Ignoring event for different channel type'
+      );
+      return null;
+    }
+
+    this.logger.debug(
+      {
+        event_type: eventType,
+        raw_event_type: webhookData.eventType,
+        conversation_id: conversationId,
+      },
+      'Processing webhook event'
+    );
+
+    return { webhookData, eventType, conversationId };
+  }
+
+  /**
    * Extract conversation ID from webhook payload (implemented by subclasses)
    */
   protected abstract extractConversationId(payload: unknown): ConversationId | null;

--- a/packages/core/src/channels/base.ts
+++ b/packages/core/src/channels/base.ts
@@ -351,15 +351,6 @@ export abstract class BaseChannel {
       return null;
     }
 
-    this.logger.debug(
-      {
-        event_type: eventType,
-        raw_event_type: webhookData.eventType,
-        conversation_id: conversationId,
-      },
-      'Processing webhook event'
-    );
-
     return { webhookData, eventType, conversationId };
   }
 

--- a/packages/core/src/channels/base.ts
+++ b/packages/core/src/channels/base.ts
@@ -6,6 +6,8 @@ import {
   ProfileId,
   MemoryMode,
   MemoryModeSchema,
+  isConversationId,
+  isProfileId,
 } from '../types/index';
 import { TACConfig } from '../lib/config';
 import { ConversationClient } from '../clients/conversation';
@@ -355,14 +357,54 @@ export abstract class BaseChannel {
   }
 
   /**
-   * Extract conversation ID from webhook payload (implemented by subclasses)
+   * Extract conversation ID from webhook payload with type validation.
+   *
+   * Extracts conversationId from webhookData.data?.conversationId || webhookData.data?.id,
+   * validates the value is a non-empty string, and ensures it passes isConversationId check.
+   *
+   * This prevents invalid IDs from causing downstream issues like incorrect Map key
+   * matching in CONVERSATION_UPDATED self-filtering or propagating malformed IDs.
    */
-  protected abstract extractConversationId(payload: unknown): ConversationId | null;
+  protected extractConversationId(payload: unknown): ConversationId | null {
+    if (!payload || typeof payload !== 'object') {
+      return null;
+    }
+
+    const webhookData = payload as ConversationWebhookPayload;
+    const conversationId = webhookData.data?.conversationId || webhookData.data?.id;
+
+    // Validate type and format before casting to ConversationId
+    if (conversationId && typeof conversationId === 'string' && isConversationId(conversationId)) {
+      return conversationId;
+    }
+
+    return null;
+  }
 
   /**
-   * Extract profile ID from webhook payload (implemented by subclasses)
+   * Extract profile ID from webhook payload with type validation.
+   *
+   * Extracts profileId from webhookData.data?.profileId,
+   * validates the value is a non-empty string, and ensures it passes isProfileId check.
+   *
+   * This prevents invalid IDs from propagating downstream and ensures consistent
+   * validation across all channel types.
    */
-  protected abstract extractProfileId(payload: unknown): ProfileId | null;
+  protected extractProfileId(payload: unknown): ProfileId | null {
+    if (!payload || typeof payload !== 'object') {
+      return null;
+    }
+
+    const webhookData = payload as ConversationWebhookPayload;
+    const profileId = webhookData.data?.profileId;
+
+    // Validate type and format before casting to ProfileId
+    if (profileId && typeof profileId === 'string' && isProfileId(profileId)) {
+      return profileId;
+    }
+
+    return null;
+  }
 
   /**
    * Retrieve memory only when memoryMode === 'always'.

--- a/packages/core/src/channels/messaging.ts
+++ b/packages/core/src/channels/messaging.ts
@@ -8,7 +8,6 @@ import {
   ProfileId,
   SendMessageActionRequest,
   isConversationId,
-  isProfileId,
 } from '../types/index';
 import axios from 'axios';
 import { BaseChannel, BaseChannelEvents, BaseChannelOptions } from './base';
@@ -420,42 +419,6 @@ export abstract class MessagingChannel extends BaseChannel {
       );
       await this.endConversation(conversationId);
     }
-  }
-
-  /**
-   * Extract conversation ID from webhook payload
-   */
-  protected extractConversationId(payload: unknown): ConversationId | null {
-    const webhookData = payload as ConversationWebhookPayload;
-    const conversationId = webhookData.data?.conversationId || webhookData.data?.id;
-
-    if (conversationId && isConversationId(conversationId)) {
-      return conversationId;
-    }
-
-    return null;
-  }
-
-  /**
-   * Extract profile ID from webhook payload
-   */
-  protected extractProfileId(payload: unknown): ProfileId | null {
-    const webhookData = payload as ConversationWebhookPayload;
-    const profileId = webhookData.data?.profileId;
-
-    if (profileId && isProfileId(profileId)) {
-      this.logger.debug(
-        { profile_id: profileId, conversation_id: webhookData.data?.conversationId },
-        'Extracted profile ID from webhook payload'
-      );
-      return profileId;
-    }
-
-    this.logger.debug(
-      { conversation_id: webhookData.data?.conversationId },
-      'Profile ID missing or invalid in webhook payload'
-    );
-    return null;
   }
 
   /**

--- a/packages/core/src/channels/messaging.ts
+++ b/packages/core/src/channels/messaging.ts
@@ -169,39 +169,13 @@ export abstract class MessagingChannel extends BaseChannel {
    * Process messaging channel webhook from Conversation Orchestrator
    */
   public async processWebhook(payload: unknown, idempotencyToken?: string): Promise<void> {
-    this.logger.debug({ operation: 'webhook_processing' }, 'Processing webhook');
-
     try {
-      if (idempotencyToken && this.isDuplicateWebhook(idempotencyToken)) {
-        this.logger.debug({ idempotency_token: idempotencyToken }, 'Skipping duplicate webhook');
+      const result = this.preprocessWebhook(payload, idempotencyToken);
+      if (!result) {
         return;
       }
 
-      if (!this.validateWebhookPayload(payload)) {
-        throw new Error('Invalid webhook payload');
-      }
-
-      const webhookData = payload as ConversationWebhookPayload;
-      const eventType = webhookData.eventType;
-      const conversationId = webhookData.data?.conversationId || webhookData.data?.id;
-
-      // Self-filter: ignore events meant for other channel types
-      if (!this.isEventForThisChannel(webhookData)) {
-        this.logger.debug(
-          { event_type: eventType, channel: this.channelType, conversation_id: conversationId },
-          'Ignoring event for different channel type'
-        );
-        return;
-      }
-
-      this.logger.info(
-        {
-          event_type: eventType,
-          raw_event_type: webhookData.eventType,
-          conversation_id: conversationId,
-        },
-        'Processing webhook event'
-      );
+      const { webhookData, eventType, conversationId } = result;
 
       switch (eventType) {
         case 'CONVERSATION_CREATED':
@@ -242,10 +216,6 @@ export abstract class MessagingChannel extends BaseChannel {
       if (idempotencyToken) {
         this.removeWebhookToken(idempotencyToken);
       }
-      this.logger.error(
-        { err: error, operation: 'webhook_processing' },
-        'Webhook processing error'
-      );
       this.handleError(error instanceof Error ? error : new Error(String(error)), { payload });
     }
   }
@@ -444,7 +414,7 @@ export abstract class MessagingChannel extends BaseChannel {
 
     // Check if conversation is closed
     if (payload.data?.status === 'CLOSED') {
-      this.logger.info(
+      this.logger.debug(
         { conversation_id: conversationId, status: payload.data.status },
         'Conversation closed, cleaning up'
       );

--- a/packages/core/src/channels/voice.ts
+++ b/packages/core/src/channels/voice.ts
@@ -16,6 +16,7 @@ import {
   ConversationRelayCallbackPayload,
   InitiateVoiceConversationOptions,
   InitiateVoiceConversationOptionsSchema,
+  ConversationWebhookPayload,
 } from '../types/index';
 import type { InitiateVoiceConversationResult } from '../types/conversation';
 import { BaseChannel, BaseChannelEvents, BaseChannelOptions } from './base';
@@ -122,12 +123,74 @@ export class VoiceChannel extends BaseChannel {
   }
 
   /**
-   * Process webhook - Voice channel doesn't use traditional webhooks,
-   * but this method is required by the base class
+   * Process conversation webhooks for cleanup.
+   *
+   * Voice channel processes CONVERSATION_UPDATED events:
+   * - CLOSED status: Clean up local session state
+   *
+   * Note: Conversation tracking uses instance-local memory. In multi-instance
+   * deployments, webhooks may route to a different instance, preventing cleanup.
+   *
+   * @param payload - Raw webhook event data from Twilio
+   * @param idempotencyToken - Optional Twilio idempotency token from request headers
    */
-  public processWebhook(_payload: unknown): Promise<void> {
-    this.logger.warn('processWebhook called but Voice channel uses WebSocket connections');
-    return Promise.resolve();
+  public async processWebhook(payload: unknown, idempotencyToken?: string): Promise<void> {
+    try {
+      const result = this.preprocessWebhook(payload, idempotencyToken);
+      if (!result) {
+        return;
+      }
+
+      const { webhookData, eventType, conversationId } = result;
+
+      switch (eventType) {
+        case 'CONVERSATION_UPDATED':
+          this.logger.debug(
+            { conversation_id: conversationId, status: webhookData.data?.status },
+            'Handling CONVERSATION_UPDATED'
+          );
+          await this.handleConversationUpdated(webhookData);
+          break;
+
+        default:
+          this.logger.warn(
+            {
+              event_type: eventType,
+              raw_event_type: webhookData.eventType,
+              conversation_id: conversationId,
+            },
+            'Unhandled event type - this event will be ignored'
+          );
+      }
+
+      this.logger.debug({ event_type: eventType }, 'Webhook processing completed');
+    } catch (error) {
+      // Remove the token so retries are not blocked
+      if (idempotencyToken) {
+        this.removeWebhookToken(idempotencyToken);
+      }
+      this.handleError(error instanceof Error ? error : new Error(String(error)), { payload });
+    }
+  }
+
+  /**
+   * Handle conversation updated event
+   */
+  private async handleConversationUpdated(payload: ConversationWebhookPayload): Promise<void> {
+    const conversationId = this.extractConversationId(payload);
+
+    if (!conversationId) {
+      throw new Error('Missing conversation ID in conversation.updated event');
+    }
+
+    // Check if conversation is closed
+    if (payload.data?.status === 'CLOSED') {
+      this.logger.debug(
+        { conversation_id: conversationId, status: payload.data.status },
+        'Conversation closed, cleaning up'
+      );
+      await this.endConversation(conversationId);
+    }
   }
 
   /**
@@ -844,19 +907,31 @@ export class VoiceChannel extends BaseChannel {
   }
 
   /**
-   * Extract conversation ID - Not applicable for Voice channel
+   * Extract conversation ID from webhook payload
    */
-  protected extractConversationId(_payload: unknown): ConversationId | null {
-    // Voice channel doesn't use traditional webhooks
-    return null;
+  protected extractConversationId(payload: unknown): ConversationId | null {
+    if (!payload || typeof payload !== 'object') {
+      return null;
+    }
+
+    const webhookData = payload as ConversationWebhookPayload;
+    const conversationId = webhookData.data?.conversationId || webhookData.data?.id;
+
+    return conversationId ? (conversationId as ConversationId) : null;
   }
 
   /**
-   * Extract profile ID - Not applicable for Voice channel
+   * Extract profile ID from webhook payload
    */
-  protected extractProfileId(_payload: unknown): ProfileId | null {
-    // Voice channel doesn't use traditional webhooks
-    return null;
+  protected extractProfileId(payload: unknown): ProfileId | null {
+    if (!payload || typeof payload !== 'object') {
+      return null;
+    }
+
+    const webhookData = payload as ConversationWebhookPayload;
+    const profileId = webhookData.data?.profileId;
+
+    return profileId ? (profileId as ProfileId) : null;
   }
 
   /**

--- a/packages/core/src/channels/voice.ts
+++ b/packages/core/src/channels/voice.ts
@@ -153,7 +153,7 @@ export class VoiceChannel extends BaseChannel {
           break;
 
         default:
-          this.logger.warn(
+          this.logger.debug(
             {
               event_type: eventType,
               raw_event_type: webhookData.eventType,

--- a/packages/core/src/channels/voice.ts
+++ b/packages/core/src/channels/voice.ts
@@ -907,34 +907,6 @@ export class VoiceChannel extends BaseChannel {
   }
 
   /**
-   * Extract conversation ID from webhook payload
-   */
-  protected extractConversationId(payload: unknown): ConversationId | null {
-    if (!payload || typeof payload !== 'object') {
-      return null;
-    }
-
-    const webhookData = payload as ConversationWebhookPayload;
-    const conversationId = webhookData.data?.conversationId || webhookData.data?.id;
-
-    return conversationId ? (conversationId as ConversationId) : null;
-  }
-
-  /**
-   * Extract profile ID from webhook payload
-   */
-  protected extractProfileId(payload: unknown): ProfileId | null {
-    if (!payload || typeof payload !== 'object') {
-      return null;
-    }
-
-    const webhookData = payload as ConversationWebhookPayload;
-    const profileId = webhookData.data?.profileId;
-
-    return profileId ? (profileId as ProfileId) : null;
-  }
-
-  /**
    * Cleanup channel state on shutdown
    *
    * Note: WebSocket connections are managed by the server and closed there.

--- a/packages/server/src/lib/server.ts
+++ b/packages/server/src/lib/server.ts
@@ -42,6 +42,11 @@ export interface TACServerConfig {
 
   /** Custom webhook paths */
   webhookPaths?: {
+    /**
+     * @deprecated Use `conversation` instead. This field will be removed in a future version.
+     * If both `messaging` and `conversation` are set, `conversation` takes precedence.
+     */
+    messaging?: string;
     conversation?: string;
     twiml?: string;
     ws?: string;
@@ -118,14 +123,24 @@ export class TACServer {
 
   constructor(tac: TAC, config: TACServerConfig = {}) {
     this.tac = tac;
+
+    // Handle deprecated `messaging` field: log warning and apply fallback if needed
+    const webhookPaths = { ...DEFAULT_CONFIG.webhookPaths, ...config.webhookPaths };
+    if (config.webhookPaths?.messaging) {
+      console.warn(
+        'TACServer: The "webhookPaths.messaging" field is deprecated and will be removed in a future version. ' +
+          'Please update your configuration to use "webhookPaths.conversation" instead.'
+      );
+      // If conversation isn't explicitly set, use messaging value as fallback
+      if (!config.webhookPaths.conversation) {
+        webhookPaths.conversation = config.webhookPaths.messaging;
+      }
+    }
+
     this.config = {
       ...DEFAULT_CONFIG,
       ...config,
-      // Deep merge webhookPaths to preserve defaults while allowing overrides
-      webhookPaths: {
-        ...DEFAULT_CONFIG.webhookPaths,
-        ...config.webhookPaths,
-      },
+      webhookPaths,
       // Deep merge conversationRelayConfig to preserve defaults while allowing overrides
       conversationRelayConfig: {
         ...DEFAULT_CONFIG.conversationRelayConfig,

--- a/packages/server/src/lib/server.ts
+++ b/packages/server/src/lib/server.ts
@@ -42,7 +42,7 @@ export interface TACServerConfig {
 
   /** Custom webhook paths */
   webhookPaths?: {
-    messaging?: string;
+    conversation?: string;
     twiml?: string;
     ws?: string;
     conversationRelayCallback?: string;
@@ -67,7 +67,7 @@ const DEFAULT_CONFIG = {
   host: '0.0.0.0',
   port: 8000,
   webhookPaths: {
-    messaging: '/webhook',
+    conversation: '/webhook',
     twiml: '/twiml',
     ws: '/ws',
     conversationRelayCallback: '/conversation-relay-callback',
@@ -109,10 +109,12 @@ export class TACServer {
   private readonly config: Required<
     Omit<TACServerConfig, 'fastify' | 'fastifyInstance' | 'voiceChannel' | 'messagingChannels'>
   >;
-  /** All enabled messaging channels — webhooks are fanned out to each one */
+  /** All enabled messaging channels */
   private readonly messagingChannels: MessagingChannel[];
   /** Voice channel instance */
   private readonly voiceChannel: VoiceChannel | undefined;
+  /** All channels that need webhook processing (voice + messaging) */
+  private readonly webhookChannels: (VoiceChannel | MessagingChannel)[];
 
   constructor(tac: TAC, config: TACServerConfig = {}) {
     this.tac = tac;
@@ -144,10 +146,16 @@ export class TACServer {
         ] as (MessagingChannel | undefined)[]
       ).filter((ch): ch is MessagingChannel => ch != null);
 
-    if (this.messagingChannels.length === 0) {
-      // eslint-disable-next-line no-console -- Fastify logger not yet initialized
+    // Gather all channels that need webhook processing
+    this.webhookChannels = [];
+    if (this.voiceChannel) {
+      this.webhookChannels.push(this.voiceChannel);
+    }
+    this.webhookChannels.push(...this.messagingChannels);
+
+    if (this.webhookChannels.length === 0) {
       console.warn(
-        'TACServer: No messaging channels configured. Messaging webhooks will be disabled. Register a MessagingChannel (e.g., "sms", "rcs", "chat", or "whatsapp") with TAC to enable messaging.'
+        'TACServer: No channels configured for webhook processing. Register channels with TAC to enable webhooks.'
       );
     }
     // Use the user-supplied Fastify instance if provided; otherwise create
@@ -224,22 +232,25 @@ export class TACServer {
       },
     };
 
-    // Messaging webhook — fan out to all enabled messaging channels (each self-filters)
-    if (this.messagingChannels.length > 0) {
+    // Conversation Orchestrator webhook — fan out to all enabled channels
+    if (this.webhookChannels.length > 0) {
       this.fastify.post(
-        this.config.webhookPaths.messaging || '/webhook',
+        this.config.webhookPaths.conversation || '/webhook',
         validateSignature,
         async (request: FastifyRequest, reply: FastifyReply) => {
           const rawHeader = request.headers['i-twilio-idempotency-token'];
           const idempotencyToken = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
-          for (const channel of this.messagingChannels) {
+
+          // Fan out to all channels
+          for (const channel of this.webhookChannels) {
             channel.processWebhook(request.body, idempotencyToken).catch((err: unknown) => {
               this.fastify.log.error(
                 { err, channel: channel.channelType },
-                'Messaging webhook processing error'
+                'Webhook processing error'
               );
             });
           }
+
           await reply.code(200).send({ status: 'ok' });
         }
       );
@@ -487,7 +498,7 @@ export class TACServer {
         {
           host: this.config.host,
           port: this.config.port,
-          messaging_webhook: this.config.webhookPaths.messaging,
+          conversation_webhook: this.config.webhookPaths.conversation,
           twiml_webhook: this.config.webhookPaths.twiml,
           ws_websocket: this.config.webhookPaths.ws,
           conversation_relay_callback: this.config.webhookPaths.conversationRelayCallback,

--- a/tests/base-channel.test.ts
+++ b/tests/base-channel.test.ts
@@ -23,17 +23,6 @@ class TestChannel extends BaseChannel {
     // Test implementation
   }
 
-  protected extractConversationId(payload: unknown): ConversationId | null {
-    const webhookData = payload as ConversationWebhookPayload;
-    const conversationId = webhookData.data?.conversationId || webhookData.data?.id;
-    return conversationId ? (conversationId as ConversationId) : null;
-  }
-
-  protected extractProfileId(payload: unknown): ProfileId | null {
-    const webhookData = payload as ConversationWebhookPayload;
-    return webhookData.data?.profileId ? (webhookData.data.profileId as ProfileId) : null;
-  }
-
   // Expose protected methods for testing
   public testIsDuplicateWebhook(token: string): boolean {
     return this.isDuplicateWebhook(token);

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1229,3 +1229,164 @@ describe('TACServer WebSocket signature validation', () => {
     expect(closeCode).toBe(1008);
   });
 });
+
+describe('TACServer webhookPaths.messaging deprecation', () => {
+  const getTestConfig = () => ({
+    accountSid: 'ACtest123456789',
+    authToken: 'test_token_123',
+    apiKey: 'test_api_key',
+    apiSecret: 'test_api_token',
+    phoneNumber: '+15551234567',
+    conversationConfigurationId: 'conv_configuration_01kbjqhn79f0fvwfsxqzd5nqhd',
+  });
+
+  let tac: TAC;
+  let server: TACServer;
+  let currentPort: number;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    mockValidateRequest.mockReset();
+    mockValidateRequestWithBody.mockReset();
+    mockValidateRequest.mockReturnValue(true);
+
+    currentPort = getNextPort();
+
+    const config = new TACConfig(getTestConfig());
+    tac = await createTestTAC(config);
+
+    const smsChannel = new SMSChannel(tac);
+    const voiceChannel = new VoiceChannel(tac);
+    tac.registerChannel(smsChannel);
+    tac.registerChannel(voiceChannel);
+
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    consoleWarnSpy.mockRestore();
+    if (server) {
+      await server.stop().catch(() => {});
+    }
+    tac.shutdown();
+  });
+
+  it('should log deprecation warning when only messaging is set', async () => {
+    server = new TACServer(tac, {
+      port: currentPort,
+      webhookPaths: {
+        messaging: '/old-webhook',
+      },
+    });
+
+    // Warning logged during construction
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'TACServer: The "webhookPaths.messaging" field is deprecated and will be removed in a future version. ' +
+          'Please update your configuration to use "webhookPaths.conversation" instead.'
+      )
+    );
+
+    await server.start();
+
+    // Verify the webhook is registered at the messaging path (now used as conversation)
+    const response = await fetch(`http://localhost:${currentPort}/old-webhook`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'eventType=COMMUNICATION_CREATED&data=%7B%22conversationId%22%3A%22CH123%22%7D',
+    });
+
+    expect(response.status).not.toBe(404);
+  });
+
+  it('should use conversation and warn when both messaging and conversation are set', async () => {
+    server = new TACServer(tac, {
+      port: currentPort,
+      webhookPaths: {
+        messaging: '/old-webhook',
+        conversation: '/new-webhook',
+      },
+    });
+
+    // Warning logged during construction
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'TACServer: The "webhookPaths.messaging" field is deprecated and will be removed in a future version. ' +
+          'Please update your configuration to use "webhookPaths.conversation" instead.'
+      )
+    );
+
+    await server.start();
+
+    // Verify the webhook is registered at the conversation path (conversation takes precedence)
+    const conversationResponse = await fetch(`http://localhost:${currentPort}/new-webhook`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'eventType=COMMUNICATION_CREATED&data=%7B%22conversationId%22%3A%22CH123%22%7D',
+    });
+
+    expect(conversationResponse.status).not.toBe(404);
+
+    // Verify the old webhook path is NOT registered (ignored when conversation is set)
+    const messagingResponse = await fetch(`http://localhost:${currentPort}/old-webhook`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'eventType=COMMUNICATION_CREATED&data=%7B%22conversationId%22%3A%22CH123%22%7D',
+    });
+
+    expect(messagingResponse.status).toBe(404);
+  });
+
+  it('should not log warning when only conversation is set', async () => {
+    server = new TACServer(tac, {
+      port: currentPort,
+      webhookPaths: {
+        conversation: '/new-webhook',
+      },
+    });
+
+    // Should not have any deprecation warnings
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+    await server.start();
+
+    // Verify the webhook is registered at the conversation path
+    const response = await fetch(`http://localhost:${currentPort}/new-webhook`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'eventType=COMMUNICATION_CREATED&data=%7B%22conversationId%22%3A%22CH123%22%7D',
+    });
+
+    expect(response.status).not.toBe(404);
+  });
+
+  it('should not log warning when neither messaging nor conversation is set', async () => {
+    server = new TACServer(tac, {
+      port: currentPort,
+    });
+
+    // Should not have any deprecation warnings
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+    await server.start();
+
+    // Verify default webhook path is used
+    const response = await fetch(`http://localhost:${currentPort}/webhook`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'eventType=COMMUNICATION_CREATED&data=%7B%22conversationId%22%3A%22CH123%22%7D',
+    });
+
+    expect(response.status).not.toBe(404);
+  });
+});

--- a/tests/voice-channel.test.ts
+++ b/tests/voice-channel.test.ts
@@ -1443,4 +1443,116 @@ describe('VoiceChannel', () => {
     });
   });
 
+  describe('webhook processing', () => {
+    it('should clean up session when conversation is closed', async () => {
+      const tac = await createTestTAC(getTestConfig());
+      const voiceChannel = new VoiceChannel(tac);
+
+      // Simulate a voice conversation started (normally happens via WebSocket)
+      (voiceChannel as any).startConversation('CHtest123456789', undefined);
+
+      expect(voiceChannel.isConversationActive('CHtest123456789' as any)).toBe(true);
+
+      // Process CONVERSATION_UPDATED webhook with CLOSED status
+      await voiceChannel.processWebhook({
+        eventType: 'CONVERSATION_UPDATED',
+        data: {
+          id: 'CHtest123456789',
+          status: 'CLOSED',
+        },
+      });
+
+      expect(voiceChannel.isConversationActive('CHtest123456789' as any)).toBe(false);
+    });
+
+    it('should trigger onConversationEnded callback when closed', async () => {
+      const tac = await createTestTAC(getTestConfig());
+      const voiceChannel = new VoiceChannel(tac);
+      const captured: ConversationSession[] = [];
+
+      tac.onConversationEnded(({ session }) => {
+        captured.push(session);
+      });
+      tac.registerChannel(voiceChannel);
+
+      // Start conversation
+      (voiceChannel as any).startConversation('CHtest123456789', undefined);
+
+      // Close conversation
+      await voiceChannel.processWebhook({
+        eventType: 'CONVERSATION_UPDATED',
+        data: { id: 'CHtest123456789', status: 'CLOSED' },
+      });
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].conversationId).toBe('CHtest123456789');
+      expect(captured[0].channel).toBe('voice');
+    });
+
+    it('should handle duplicate webhooks via idempotency token', async () => {
+      const tac = await createTestTAC(getTestConfig());
+      const voiceChannel = new VoiceChannel(tac);
+
+      // Start conversation
+      (voiceChannel as any).startConversation('CHtest123456789', undefined);
+
+      const idempotencyToken = 'idempotency-token-123';
+
+      // First webhook should process
+      await voiceChannel.processWebhook(
+        {
+          eventType: 'CONVERSATION_UPDATED',
+          data: { id: 'CHtest123456789', status: 'CLOSED' },
+        },
+        idempotencyToken
+      );
+
+      expect(voiceChannel.isConversationActive('CHtest123456789' as any)).toBe(false);
+
+      // Restart the same conversation to test duplicate webhook
+      (voiceChannel as any).startConversation('CHtest123456789', undefined);
+      expect(voiceChannel.isConversationActive('CHtest123456789' as any)).toBe(true);
+
+      // Duplicate webhook should be ignored (same idempotency token)
+      await voiceChannel.processWebhook(
+        {
+          eventType: 'CONVERSATION_UPDATED',
+          data: { id: 'CHtest123456789', status: 'CLOSED' },
+        },
+        idempotencyToken
+      );
+
+      // Conversation should still be active (duplicate was ignored)
+      expect(voiceChannel.isConversationActive('CHtest123456789' as any)).toBe(true);
+    });
+
+    it('should ignore webhook for unknown conversation', async () => {
+      const tac = await createTestTAC(getTestConfig());
+      const voiceChannel = new VoiceChannel(tac);
+
+      // No error should be thrown for unknown conversation
+      await voiceChannel.processWebhook({
+        eventType: 'CONVERSATION_UPDATED',
+        data: { id: 'CHunknown', status: 'CLOSED' },
+      });
+    });
+
+    it('should ignore unhandled event types', async () => {
+      const tac = await createTestTAC(getTestConfig());
+      const voiceChannel = new VoiceChannel(tac);
+
+      // Start conversation
+      (voiceChannel as any).startConversation('CHtest123456789', undefined);
+
+      // Process unhandled event type (should not throw)
+      await voiceChannel.processWebhook({
+        eventType: 'UNKNOWN_EVENT_TYPE',
+        data: { id: 'CHtest123456789' },
+      });
+
+      // Conversation should still be active
+      expect(voiceChannel.isConversationActive('CHtest123456789' as any)).toBe(true);
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary

Implements CONVERSATION_UPDATED/CLOSED webhook handling in VoiceChannel to achieve 1:1 parity with the Python SDK. All Conversation Orchestrator webhooks are now fanned out to both voice and messaging channels, with logging improvements and deprecation of `webhookPaths.messaging` in favor of `webhookPaths.conversation`.

Consolidates webhook ID extraction methods into BaseChannel with proper validation to prevent invalid IDs from propagating downstream.

## Changes

### Core Implementation
- **VoiceChannel**: Added `processWebhook()` method to handle CONVERSATION_UPDATED events with CLOSED status for conversation cleanup
- **BaseChannel**: Extracted common webhook preprocessing logic into `preprocessWebhook()` helper (validation, deduplication, filtering, data extraction)
- **BaseChannel**: Consolidated `extractConversationId()` and `extractProfileId()` methods with type validation (moved from VoiceChannel and MessagingChannel)
  - Both methods now validate `typeof === 'string'` and use `isConversationId`/`isProfileId` type guards
  - Prevents invalid IDs from causing downstream issues (incorrect Map key matching in event filtering, malformed ID propagation)
  - Eliminates code duplication (removed ~60 lines across VoiceChannel and MessagingChannel)

### Logging Improvements
- **VoiceChannel**: Downgraded unhandled webhook event logging from warn to debug (reduces noise from expected events like CONVERSATION_CREATED)
- **BaseChannel**: Removed redundant "Processing webhook event" log at end of `preprocessWebhook()` - subclasses already log specific event handling

### Server Updates & Deprecation
- **Deprecated** `webhookPaths.messaging` field in favor of `webhookPaths.conversation` (breaking change warning added for future v2)
  - TypeScript `@deprecated` JSDoc annotation for IDE warnings
  - Runtime deprecation warning when `messaging` field is used
  - Automatic fallback to `messaging` value when `conversation` is not set
  - `conversation` takes precedence when both are provided
- Renamed webhook path internally from "messaging" → "conversation" (more accurate since it handles all channels)
- Added `webhookChannels` array combining voice and messaging channels
- Updated webhook endpoint to fan out to all channels (matching Python architecture)

### Testing
- Added 9 comprehensive tests:
  - 5 tests for voice webhook processing (session cleanup, callbacks, idempotency, error handling)
  - 4 tests for `webhookPaths.messaging` deprecation (all scenarios covered)
- Updated BaseChannel test implementation to remove now-unnecessary method overrides

### Documentation
- Updated CLAUDE.md webhook path configuration
- Added comprehensive JSDoc comments
- Cleaned up documentation to match Python SDK style

## How It Works

**Voice channel dual cleanup mechanisms:**
1. **Primary cleanup**: WebSocket disconnect (when call ends)
2. **Secondary cleanup**: CONVERSATION_UPDATED/CLOSED webhook (fallback/safety net)

Self-filtering via `isEventForThisChannel()` prevents duplicate cleanup if conversation was already ended. The server fans out all CO webhooks, but channels ignore events they don't need (logged at debug level, not warn).

**ID Extraction with Validation:**
- `extractConversationId()` and `extractProfileId()` now in BaseChannel
- Both validate `typeof value === 'string'` before type guard check
- Prevents VoiceChannel's previous security issue of casting without validation
- Single source of truth for ID extraction logic across all channels

**Logging flow:**
- `preprocessWebhook()`: Initial "Processing webhook" log + filtering logs
- Subclass `processWebhook()`: Specific "Handling <EVENT_TYPE>" logs per case
- No redundant middle logs between preprocessing and handling

**Deprecation flow:**
- User sets `webhookPaths.messaging` → Warning logged immediately + fallback applied
- User sets both → Warning logged + `conversation` takes precedence
- User sets only `conversation` → No warning (recommended path)

## Testing

- Manually tested with live voice call - webhook correctly processes CLOSED status and cleans up conversation state
- All 565 tests pass (9 new tests added)
- TypeScript compiles with no errors
- No new linting errors
- BaseChannel test updated to reflect consolidated extraction methods

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (CLAUDE.md)
- [x] Code formatted
- [x] All tests passing
- [x] Matches Python SDK architecture
- [x] Code review feedback addressed
- [x] Deprecation implemented with proper warnings
- [x] ID extraction consolidated with validation