### PR TITLE
fix: Guard MemoryClient creation and fix flaky memory test

### DIFF
--- a/packages/core/src/lib/tac.ts
+++ b/packages/core/src/lib/tac.ts
@@ -113,10 +113,6 @@ export class TAC {
       );
 
       tac.memoryStoreId = conversationConfig.memoryStoreId;
-      // TODO(conv-orch): Remove once the Actions API resolves the V1 Chat service SID
-      // server-side — see the conversationsV1ServiceSid field comment above.
-      tac.conversationsV1ServiceSid =
-        conversationConfig.conversationsV1Bridge?.serviceId ?? undefined;
       if (conversationConfig.memoryStoreId) {
         tac.memoryClient = new MemoryClient(
           tac.config,

--- a/packages/core/src/lib/tac.ts
+++ b/packages/core/src/lib/tac.ts
@@ -113,18 +113,24 @@ export class TAC {
       );
 
       tac.memoryStoreId = conversationConfig.memoryStoreId;
-      tac.memoryClient = new MemoryClient(
-        tac.config,
-        conversationConfig.memoryStoreId,
-        tac.logger.child({ component: 'memory' })
-      );
+      // TODO(conv-orch): Remove once the Actions API resolves the V1 Chat service SID
+      // server-side — see the conversationsV1ServiceSid field comment above.
+      tac.conversationsV1ServiceSid =
+        conversationConfig.conversationsV1Bridge?.serviceId ?? undefined;
+      if (conversationConfig.memoryStoreId) {
+        tac.memoryClient = new MemoryClient(
+          tac.config,
+          conversationConfig.memoryStoreId,
+          tac.logger.child({ component: 'memory' })
+        );
+      }
 
       tac.knowledgeClient = new KnowledgeClient(
         tac.config,
         tac.logger.child({ component: 'knowledge' })
       );
 
-      if (tac.config.cintelConfigurationId) {
+      if (tac.config.cintelConfigurationId && tac.memoryClient) {
         tac.cintelProcessor = new OperatorResultProcessor(
           tac.memoryClient,
           {

--- a/packages/core/src/types/conversation.ts
+++ b/packages/core/src/types/conversation.ts
@@ -395,7 +395,8 @@ export const ConversationConfigurationSchema = z.object({
   conversationGroupingType: ConversationGroupingTypeSchema,
   memoryStoreId: z
     .string()
-    .regex(/^mem_(store|service)_[0-7][0-9a-z]{25}$/, 'Invalid Memory Store ID format'),
+    .regex(/^mem_(store|service)_[0-7][0-9a-z]{25}$/, 'Invalid Memory Store ID format')
+    .optional(),
   channelSettings: z.record(z.string(), ChannelSettingsSchema).nullable().optional(),
   statusCallbacks: z.array(StatusCallbackSchema).max(20).nullable().optional(),
   intelligenceConfigurationIds: z.array(z.string()).max(5).nullable().optional(),

--- a/tests/helpers/tac.ts
+++ b/tests/helpers/tac.ts
@@ -17,7 +17,7 @@ afterEach(() => {
  */
 export async function createTestTAC(
   configOrData: TACConfig | TACConfigData,
-  memoryStoreIdFromConfig: string = 'mem_service_01kbjqhhdpft0tbp21jt4ktbxg'
+  memoryStoreIdFromConfig: string | undefined = 'mem_service_01kbjqhhdpft0tbp21jt4ktbxg'
 ): Promise<TAC> {
   const config = configOrData instanceof TACConfig ? configOrData : new TACConfig(configOrData);
 

--- a/tests/helpers/tac.ts
+++ b/tests/helpers/tac.ts
@@ -17,7 +17,7 @@ afterEach(() => {
  */
 export async function createTestTAC(
   configOrData: TACConfig | TACConfigData,
-  memoryStoreIdFromConfig: string | undefined = 'mem_service_01kbjqhhdpft0tbp21jt4ktbxg'
+  memoryStoreIdFromConfig: string | null = 'mem_service_01kbjqhhdpft0tbp21jt4ktbxg'
 ): Promise<TAC> {
   const config = configOrData instanceof TACConfig ? configOrData : new TACConfig(configOrData);
 
@@ -26,7 +26,7 @@ export async function createTestTAC(
     id: config.conversationConfigurationId,
     description: 'test config',
     conversationGroupingType: 'GROUP_BY_PARTICIPANT_ADDRESSES' as const,
-    memoryStoreId: memoryStoreIdFromConfig,
+    memoryStoreId: memoryStoreIdFromConfig ?? undefined,
   });
 
   const spy = vi.spyOn(ConversationClient.prototype, 'getConfiguration').mockImplementation(mockGetConfiguration);

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -358,7 +358,7 @@ describe('Memory Functionality', () => {
     });
 
     it('should return undefined when memory not configured', async () => {
-      const tac = await createTestTAC(getTestConfigWithoutMemory());
+      const tac = await createTestTAC(getTestConfigWithoutMemory(), undefined);
 
       const result = await tac.fetchProfile('profile_123');
 

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -358,7 +358,7 @@ describe('Memory Functionality', () => {
     });
 
     it('should return undefined when memory not configured', async () => {
-      const tac = await createTestTAC(getTestConfigWithoutMemory(), undefined);
+      const tac = await createTestTAC(getTestConfigWithoutMemory(), null);
 
       const result = await tac.fetchProfile('profile_123');
 


### PR DESCRIPTION
## Summary

- Only create `MemoryClient` when `memoryStoreId` is present in the conversation config response
- Guard `cintelProcessor` creation on `tac.memoryClient` being non-null
- Fix flaky test "should return undefined when memory not configured" that was timing out on CI

The test was flaky because `TAC.create` always created a `MemoryClient` regardless of whether a memory store ID was configured. The test then called `fetchProfile` expecting to hit the `if (!this.memoryClient)` early return, but since a client existed, it made a real HTTP call that hung on CI.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

## SDK Parity

- [x] Change is TypeScript-specific (no Python update needed)