### PR TITLE
ci: route npm dependency resolution through Artifactory via OIDC

### DIFF
--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -1,0 +1,41 @@
+name: 'Artifactory OIDC Auth'
+description: 'Exchange GitHub OIDC token for Artifactory access token and configure npm'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Exchange OIDC token for Artifactory access token
+      shell: bash
+      run: |
+        # 1. Request GitHub JWT with Artifactory as audience
+        GITHUB_JWT=$(curl -sS \
+          -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${ARTIFACTORY_URL}" \
+          | jq -r '.value')
+
+        # Decode and log claims for debugging (payload is base64url, not secret)
+        PAYLOAD=$(echo "$GITHUB_JWT" | cut -d. -f2 | sed 's/-/+/g; s/_/\//g' | base64 -d 2>/dev/null || true)
+        echo "::debug::OIDC claims: sub=$(echo "$PAYLOAD" | jq -r '.sub'), aud=$(echo "$PAYLOAD" | jq -r '.aud')"
+
+        # 2. Exchange GitHub JWT for Artifactory access token
+        ART_TOKEN=$(curl -sS -X POST \
+          "${ARTIFACTORY_URL}/access/api/v1/oidc/token" \
+          -d "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+          -d "subject_token=${GITHUB_JWT}" \
+          -d "subject_token_type=urn:ietf:params:oauth:token-type:id-token" \
+          | jq -r '.access_token')
+
+        if [ -z "$ART_TOKEN" ] || [ "$ART_TOKEN" = "null" ]; then
+          echo "::error::Failed to obtain Artifactory access token"
+          exit 1
+        fi
+
+        # 3. Configure npm to use Artifactory registry
+        REGISTRY="${ARTIFACTORY_URL}/artifactory/api/npm/virtual-npm-thirdparty/"
+        HOST=$(echo "${ARTIFACTORY_URL}" | sed -E 's#^https?://##')
+        {
+          echo "registry=${REGISTRY}"
+          echo "//${HOST}/artifactory/api/npm/virtual-npm-thirdparty/:_authToken=${ART_TOKEN}"
+        } > ~/.npmrc
+
+        echo "::notice::npm configured to use Artifactory registry"

--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -17,18 +17,24 @@ runs:
         PAYLOAD=$(echo "$GITHUB_JWT" | cut -d. -f2 | sed 's/-/+/g; s/_/\//g' | base64 -d 2>/dev/null || true)
         echo "::debug::OIDC claims: sub=$(echo "$PAYLOAD" | jq -r '.sub'), aud=$(echo "$PAYLOAD" | jq -r '.aud')"
 
-        # 2. Exchange GitHub JWT for Artifactory access token
-        ART_TOKEN=$(curl -sS -X POST \
-          "${ARTIFACTORY_URL}/access/api/v1/oidc/token" \
-          -d "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
-          -d "subject_token=${GITHUB_JWT}" \
-          -d "subject_token_type=urn:ietf:params:oauth:token-type:id-token" \
-          | jq -r '.access_token')
+        # 2. Exchange GitHub JWT for Artifactory access token.
+        #    Must be a JSON body and MUST include provider_name so JFrog knows
+        #    which OIDC configuration to match (without it, no token is issued).
+        #    Capture the full response so JFrog's error is visible on failure.
+        RESP=$(curl -sS "${ARTIFACTORY_URL}/access/api/v1/oidc/token" \
+          -H 'Content-Type: application/json' \
+          -d "{\"grant_type\":\"urn:ietf:params:oauth:grant-type:token-exchange\",
+               \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\",
+               \"subject_token\":\"${GITHUB_JWT}\",
+               \"provider_name\":\"github-actions\"}")
+        ART_TOKEN=$(echo "$RESP" | jq -r '.access_token // empty')
 
-        if [ -z "$ART_TOKEN" ] || [ "$ART_TOKEN" = "null" ]; then
-          echo "::error::Failed to obtain Artifactory access token"
+        if [ -z "$ART_TOKEN" ]; then
+          echo "::error::OIDC token exchange failed. Raw response (token field redacted):"
+          echo "$RESP" | jq 'if .access_token then .access_token="<redacted>" else . end' 2>/dev/null || echo "$RESP"
           exit 1
         fi
+        echo "::add-mask::$ART_TOKEN"
 
         # 3. Configure npm to use Artifactory registry
         REGISTRY="${ARTIFACTORY_URL}/artifactory/api/npm/virtual-npm-thirdparty/"

--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -1,0 +1,8 @@
+runs-on: ubuntu-x64
+steps:
+  - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+  - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+    with:
+      node-version: "22.13"
+      cache: "npm"
+  - run: npm ci

--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -1,8 +1,3 @@
 runs-on: ubuntu-x64
 steps:
   - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-  - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-    with:
-      node-version: "22.13"
-      cache: "npm"
-  - run: npm ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/getting_started/examples/*"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
 
   - package-ecosystem: "npm"
     directories:
-      - "/getting_started/examples/*"
+      - "/getting_started/examples/chat"
+      - "/getting_started/examples/handoff"
+      - "/getting_started/examples/openai"
+      - "/getting_started/examples/openai-streaming"
+      - "/getting_started/examples/outbound"
+      - "/getting_started/examples/rcs"
+      - "/getting_started/examples/relay-only"
+      - "/getting_started/examples/whatsapp"
     schedule:
       interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
   all-checks:
     name: All Checks Passed
     needs: [lint, type-check, test-node-22, test-node-24, getting-started-example, build]
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
     if: always()
     steps:
       - name: Check all job statuses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,23 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   lint:
     name: Linting
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Artifactory OIDC Auth
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/artifactory-oidc
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22.13"
           cache: "npm"
@@ -42,12 +50,16 @@ jobs:
 
   type-check:
     name: Type Check
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Artifactory OIDC Auth
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/artifactory-oidc
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22.13"
           cache: "npm"
@@ -69,12 +81,16 @@ jobs:
 
   test-node-24:
     name: Test - Node 24
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Artifactory OIDC Auth
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/artifactory-oidc
 
       - name: Set up Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24.x"
           cache: "npm"
@@ -87,12 +103,16 @@ jobs:
 
   test-node-22:
     name: Test - Node 22
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Artifactory OIDC Auth
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/artifactory-oidc
 
       - name: Set up Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22.13"
           cache: "npm"
@@ -105,12 +125,16 @@ jobs:
 
   getting-started-example:
     name: Getting Started Example
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Artifactory OIDC Auth
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/artifactory-oidc
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22.13"
           cache: "npm"
@@ -151,12 +175,16 @@ jobs:
 
   build:
     name: Build Package
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Artifactory OIDC Auth
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/artifactory-oidc
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22.13"
           cache: "npm"
@@ -176,7 +204,7 @@ jobs:
           node --input-type=module -e "import('./dist/index.js').then((tac) => { console.log('Successfully imported package'); console.log('Exports:', Object.keys(tac).slice(0, 10).join(', '), '...'); });"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist
           path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ permissions:
   contents: read
   id-token: write
 
+env:
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
 jobs:
   lint:
     name: Linting

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: ${{ github.repository_owner == 'twilio' && 'ubuntu-x64' || 'ubuntu-latest' }}
+    runs-on: ubuntu-x64
     if: github.repository_owner == 'twilio'
     permissions:
       contents: read
@@ -39,7 +39,7 @@ jobs:
   deploy:
     name: Publish to npm
     needs: [test]
-    runs-on: ${{ github.repository_owner == 'twilio' && 'ubuntu-x64' || 'ubuntu-latest' }}
+    runs-on: ubuntu-x64
     if: github.repository_owner == 'twilio'
     environment: npm
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+env:
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,19 +7,26 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'twilio' && 'ubuntu-x64' || 'ubuntu-latest' }}
+    if: github.repository_owner == 'twilio'
     permissions:
       contents: read
+      id-token: write
     timeout-minutes: 20
     strategy:
       matrix:
         node: [22, 24]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Artifactory OIDC Auth
+        uses: ./.github/actions/artifactory-oidc
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node }}
           cache: npm
+
       - run: npm ci
       - run: npm run lint
       - run: npm run typecheck
@@ -29,19 +36,23 @@ jobs:
   deploy:
     name: Publish to npm
     needs: [test]
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'twilio' && 'ubuntu-x64' || 'ubuntu-latest' }}
+    if: github.repository_owner == 'twilio'
     environment: npm
     permissions:
       contents: read
       id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      # https://docs.npmjs.com/trusted-publishers — never cache in release builds
+
+      - name: Artifactory OIDC Auth
+        uses: ./.github/actions/artifactory-oidc
+
       # Node 24+ required for npm OIDC trusted publisher support (npm >= 11.5.1)
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org
+
       - run: npm ci
 
       - name: Validate tag format and version match
@@ -61,4 +72,4 @@ jobs:
       - run: npm run build
 
       - name: Publish to npm
-        run: npm publish --ignore-scripts --provenance --access public
+        run: npm publish --registry https://registry.npmjs.org --ignore-scripts --provenance --access public


### PR DESCRIPTION
## Summary

- Add keyless GitHub OIDC → Artifactory authentication for supply chain lockdown
- Internal builds (non-fork PRs, pushes to main, releases) use Twilio-owned `ubuntu-x64` runners and resolve npm packages from Artifactory
- Fork PRs use public GitHub runners (`ubuntu-latest`) and pull from the public npm registry directly
- Pin all GitHub Actions to commit SHAs to prevent tag-hijacking attacks
- Add dependabot configuration for automated dependency updates

Closes #60

## Type of Change

- [x] New feature
- [x] Refactoring

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [ ] Tested E2E

## SDK Parity

- [x] Change is TypeScript-specific (no Python update needed)

## Implementation Details

### Composite Action (`.github/actions/artifactory-oidc/action.yml`)
Exchanges a GitHub OIDC token for a short-lived Artifactory access token, then writes `~/.npmrc` with the Artifactory npm virtual repository (`virtual-npm-thirdparty`) as the registry.

### Fork Detection
- **CI workflow**: Uses `github.event.pull_request.head.repo.fork` (correctly identifies fork PRs even though `repository_owner` is always `twilio`)
- **Release workflow**: Uses `github.repository_owner == 'twilio'` (releases only trigger from the main repo, no PR context)

### Release Publishing
Artifactory is used for `npm ci` (installing dependencies). Publishing uses `--registry https://registry.npmjs.org` to target npmjs.org with OIDC provenance.

### Reference
Matches the pattern from [twilio-agent-connect-aws PR #40](https://github.com/twilio/twilio-agent-connect-aws/pull/40), adapted for npm conventions.