### PR TITLE
(chore) Lockfile Hygiene 

### DIFF
--- a/.github/scripts/lockfile-hygiene.sh
+++ b/.github/scripts/lockfile-hygiene.sh
@@ -29,11 +29,12 @@ echo "hygiene: scanning ${count} file(s) for Twilio Artifactory hosts..."
 violations=0
 while IFS= read -r f; do
   [ -n "$f" ] || continue
-  if hits=$(grep -nEi "$PATTERNS" "$f" 2>/dev/null); then
+  if grep -qEi "$PATTERNS" "$f" 2>/dev/null; then
     violations=1
     echo "::error file=$f::Artifactory host found in $f — public consumers cannot resolve this. Regenerate against the public registry."
     echo "  ── $f"
-    echo "$hits" | sed 's/^/     /' | head -8
+    # Print only a small sample (avoids capturing a huge lockfile into memory).
+    grep -nEi "$PATTERNS" "$f" 2>/dev/null | head -8 | sed 's/^/     /'
   fi
   # npm-shrinkwrap.json ships inside the published tarball — extra-loud.
   case "$f" in

--- a/.github/scripts/lockfile-hygiene.sh
+++ b/.github/scripts/lockfile-hygiene.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Lockfile & resolver-config hygiene gate (ADR 1634 Rule 3b).
+#
+# Public SDK repos MUST stay resolvable by external consumers: a committed
+# lockfile / resolver config that names a Twilio Artifactory host breaks any
+# external `npm ci`. Twilio resolution is redirected at build time by config
+# (the OIDC action writes ~/.npmrc), never in the repo — so the committed files
+# must always point at the public registry.
+#
+# This script DETECTS violations and fails closed. It does not rewrite files;
+# remediation is to regenerate the lockfile against the public registry.
+set -euo pipefail
+
+# Known Twilio Artifactory hosts / aliases. Extend as new hosts appear.
+PATTERNS='twilio\.jfrog\.io|artifactory\.twilio|artifacts\.twilio|\.artifactory\.twilioinfra|jfrog\.twilio'
+
+# Closed, enumerated detection surface (ADR Rule 3b). npmrc files and every
+# committed lockfile / shrinkwrap. Python equivalents live in the Python repos.
+# Portable (no mapfile): newline-delimited, iterated with a while-read loop.
+FILES="$(git ls-files | grep -E '(^|/)(package-lock\.json|npm-shrinkwrap\.json|\.npmrc)$' || true)"
+
+if [ -z "$FILES" ]; then
+  echo "hygiene: no lockfiles or resolver configs tracked — nothing to check."
+  exit 0
+fi
+
+count="$(printf '%s\n' "$FILES" | grep -c .)"
+echo "hygiene: scanning ${count} file(s) for Twilio Artifactory hosts..."
+violations=0
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  if hits=$(grep -nEi "$PATTERNS" "$f" 2>/dev/null); then
+    violations=1
+    echo "::error file=$f::Artifactory host found in $f — public consumers cannot resolve this. Regenerate against the public registry."
+    echo "  ── $f"
+    echo "$hits" | sed 's/^/     /' | head -8
+  fi
+  # npm-shrinkwrap.json ships inside the published tarball — extra-loud.
+  case "$f" in
+    *npm-shrinkwrap.json)
+      echo "::warning file=$f::npm-shrinkwrap.json is published in the tarball; any Artifactory host here reaches consumers." ;;
+  esac
+done <<EOF
+$FILES
+EOF
+
+if [ "$violations" -ne 0 ]; then
+  cat <<'EOF'
+
+✗ Lockfile hygiene FAILED.
+  A committed lockfile / resolver config points at a Twilio Artifactory host.
+  External consumers cannot resolve against it.
+
+  Fix: regenerate the lockfile against the PUBLIC registry, e.g.
+    rm -f ~/.npmrc && npm_config_registry=https://registry.npmjs.org \
+      npm install --package-lock-only
+  then commit the cleaned lockfile.
+EOF
+  exit 1
+fi
+
+echo "✓ Lockfile hygiene passed — all tracked files resolve against the public registry."

--- a/.github/workflows/lockfile-hygiene.yml
+++ b/.github/workflows/lockfile-hygiene.yml
@@ -17,7 +17,7 @@ jobs:
   detect:
     name: Detect Artifactory hosts
     # Forks can't use the larger runner group; fall back to ubuntu-latest.
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Scan committed lockfiles & resolver config
@@ -25,7 +25,7 @@ jobs:
 
   clean-room-resolve:
     name: Clean-room public resolve
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/lockfile-hygiene.yml
+++ b/.github/workflows/lockfile-hygiene.yml
@@ -1,0 +1,67 @@
+name: Lockfile Hygiene
+
+# ADR 1634 Rule 3b — keep public SDK repos resolvable by external consumers.
+# Both jobs are secret-less and run identically on fork PRs and same-repo PRs:
+# they MUST resolve from the public registry only (no Artifactory, no OIDC).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    name: Detect Artifactory hosts
+    # Forks can't use the larger runner group; fall back to ubuntu-latest.
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Scan committed lockfiles & resolver config
+        run: bash .github/scripts/lockfile-hygiene.sh
+
+  clean-room-resolve:
+    name: Clean-room public resolve
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22.13"
+
+      - name: Strip any resolver config (simulate an external consumer)
+        run: |
+          # Guarantee no Twilio redirect is in effect: no user/global .npmrc,
+          # registry pinned to public npm for this job only.
+          rm -f ~/.npmrc "$HOME/.npmrc" || true
+          echo "registry=https://registry.npmjs.org/" > ~/.npmrc
+          echo "Effective npm registry:"
+          npm config get registry
+
+      - name: Clean-room install from the committed lockfile
+        env:
+          npm_config_registry: https://registry.npmjs.org/
+        run: |
+          set -e
+          echo "Resolving the root package against the public registry..."
+          npm ci --ignore-scripts --no-audit --fund=false
+          echo "✓ Root lockfile resolves publicly."
+
+      - name: Clean-room install for getting_started examples
+        env:
+          npm_config_registry: https://registry.npmjs.org/
+        run: |
+          set -e
+          shopt -s nullglob
+          fail=0
+          for dir in getting_started/examples/*/; do
+            [ -f "${dir}package-lock.json" ] || continue
+            echo "── ${dir}"
+            ( cd "$dir" && npm ci --ignore-scripts --no-audit --fund=false ) || { echo "::error::${dir} failed public resolve"; fail=1; }
+          done
+          [ "$fail" -eq 0 ] && echo "✓ All example lockfiles resolve publicly." || exit 1

--- a/.github/workflows/lockfile-hygiene.yml
+++ b/.github/workflows/lockfile-hygiene.yml
@@ -41,12 +41,14 @@ jobs:
           # or npm_config_* env that silently redirect to Artifactory — which
           # would FALSELY pass a lockfile an external consumer can't resolve.
           # So we don't trust the runner: we force npm to read ONLY our file.
-          CLEAN="$RUNNER_TEMP/clean.npmrc"
-          echo "registry=https://registry.npmjs.org/" > "$CLEAN"
-          echo "NPM_CONFIG_USERCONFIG=$CLEAN"   >> "$GITHUB_ENV"   # ignore ~/.npmrc
-          echo "NPM_CONFIG_GLOBALCONFIG=$CLEAN"  >> "$GITHUB_ENV"   # ignore /etc + prefix npmrc
+          # Use TWO separate files: npm refuses to load the same path as both
+          # user and global config ("double-loading config ... as global").
+          echo "registry=https://registry.npmjs.org/" > "$RUNNER_TEMP/user.npmrc"
+          echo "registry=https://registry.npmjs.org/" > "$RUNNER_TEMP/global.npmrc"
+          echo "NPM_CONFIG_USERCONFIG=$RUNNER_TEMP/user.npmrc"     >> "$GITHUB_ENV"  # ignore ~/.npmrc
+          echo "NPM_CONFIG_GLOBALCONFIG=$RUNNER_TEMP/global.npmrc" >> "$GITHUB_ENV"  # ignore /etc + prefix npmrc
           # Neutralize any inherited redirect env vars for all later steps.
-          echo "npm_config_registry=https://registry.npmjs.org/" >> "$GITHUB_ENV"
+          echo "npm_config_registry=https://registry.npmjs.org/"  >> "$GITHUB_ENV"
 
       - name: Prove the clean room is actually public
         run: |

--- a/.github/workflows/lockfile-hygiene.yml
+++ b/.github/workflows/lockfile-hygiene.yml
@@ -34,18 +34,36 @@ jobs:
         with:
           node-version: "22.13"
 
-      - name: Strip any resolver config (simulate an external consumer)
+      - name: Build a hermetic npm config (ignore ALL ambient config)
         run: |
-          # Guarantee no Twilio redirect is in effect: no user/global .npmrc,
-          # registry pinned to public npm for this job only.
-          rm -f ~/.npmrc "$HOME/.npmrc" || true
-          echo "registry=https://registry.npmjs.org/" > ~/.npmrc
-          echo "Effective npm registry:"
-          npm config get registry
+          # On a fork's stock runner this is already clean. On Twilio's internal
+          # runner the image MAY carry a global/system .npmrc, scoped registries,
+          # or npm_config_* env that silently redirect to Artifactory — which
+          # would FALSELY pass a lockfile an external consumer can't resolve.
+          # So we don't trust the runner: we force npm to read ONLY our file.
+          CLEAN="$RUNNER_TEMP/clean.npmrc"
+          echo "registry=https://registry.npmjs.org/" > "$CLEAN"
+          echo "NPM_CONFIG_USERCONFIG=$CLEAN"   >> "$GITHUB_ENV"   # ignore ~/.npmrc
+          echo "NPM_CONFIG_GLOBALCONFIG=$CLEAN"  >> "$GITHUB_ENV"   # ignore /etc + prefix npmrc
+          # Neutralize any inherited redirect env vars for all later steps.
+          echo "npm_config_registry=https://registry.npmjs.org/" >> "$GITHUB_ENV"
+
+      - name: Prove the clean room is actually public
+        run: |
+          echo "userconfig : $(npm config get userconfig)"
+          echo "globalconfig: $(npm config get globalconfig)"
+          REG="$(npm config get registry)"
+          echo "registry   : $REG"
+          case "$REG" in
+            https://registry.npmjs.org*) echo "✓ resolving against public npm" ;;
+            *) echo "::error::clean room is not public — registry=$REG (ambient Twilio config leaked in)"; exit 1 ;;
+          esac
+          # Belt-and-suspenders: fail if any scoped/twilio registry survived.
+          if npm config list 2>/dev/null | grep -iE 'jfrog|artifactory|:registry'; then
+            echo "::error::a scoped or Artifactory registry is still configured in the clean room"; exit 1
+          fi
 
       - name: Clean-room install from the committed lockfile
-        env:
-          npm_config_registry: https://registry.npmjs.org/
         run: |
           set -e
           echo "Resolving the root package against the public registry..."
@@ -53,8 +71,6 @@ jobs:
           echo "✓ Root lockfile resolves publicly."
 
       - name: Clean-room install for getting_started examples
-        env:
-          npm_config_registry: https://registry.npmjs.org/
         run: |
           set -e
           shopt -s nullglob


### PR DESCRIPTION
This pull request adds a new workflow and supporting script to enforce lockfile and resolver configuration hygiene for public SDK repositories. The goal is to ensure that all committed lockfiles and resolver configs only reference the public npm registry, preventing any accidental inclusion of internal Twilio Artifactory hosts, which would break external consumers’ builds.

The most important changes are:

**Lockfile Hygiene Enforcement:**

* Added a new GitHub Actions workflow (`.github/workflows/lockfile-hygiene.yml`) that runs on every push, pull request, and manual trigger to check for references to Twilio Artifactory hosts in lockfiles and `.npmrc` files.
* Introduced a shell script (`.github/scripts/lockfile-hygiene.sh`) that scans all tracked lockfiles and resolver configs for any Artifactory host patterns and fails the workflow if any are found.

**Public Registry Resolution Verification:**

* The workflow includes a “clean-room” job that strips any resolver config, sets the npm registry to the public registry, and verifies that both the root project and all `getting_started` example projects can be installed using the committed lockfiles.

These changes help ensure that the repository remains consumable by external users without internal dependencies leaking into published configuration files.