### PR TITLE
Add .worktreeinclude to copy example .env files into new worktrees

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+# Copy local env files into new worktrees (see .gitignore for what's ignored).
+# Only gitignored matches are copied, so tracked .env.example/.env.template are skipped.
+getting_started/examples/**/.env*


### PR DESCRIPTION
## Summary

New worktrees are fresh checkouts, so gitignored `.env` files under `getting_started/examples/` don't carry over — examples can't run without recreating secrets by hand. This adds a `.worktreeinclude` ([docs](https://code.claude.com/docs/en/worktrees#copy-gitignored-files-into-worktrees)) that copies them in automatically. It uses gitignore syntax and only copies files that are already gitignored, so tracked `.env.example` files are never duplicated.

`.gitignore` already covers `.env.*`/`*.env`, so this PR is `.worktreeinclude` only.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Tested E2E

## SDK Parity

This is the **TypeScript SDK**. If this change affects shared functionality, ensure the [Python SDK](https://github.com/twilio/twilio-agent-connect-python) is updated as well.

> **Tip:** Use the `/sync-to-python-sdk` skill in Claude Code to automatically generate and create a Python SDK PR from your changes.

- [x] Change is TypeScript-specific (no Python update needed)
- [ ] Python SDK PR created: <!-- link to PR in twilio-agent-connect-python -->
