### PR TITLE
Fix memory recall dropping valid results

### DIFF
--- a/packages/core/src/clients/memory.ts
+++ b/packages/core/src/clients/memory.ts
@@ -152,26 +152,50 @@ export class MemoryClient extends BaseClient {
     }
   }
 
+  /** Cap on per-item validation warnings logged per response, to avoid flooding logs. */
+  private static readonly MAX_INVALID_ITEM_LOGS = 10;
+
   /**
    * Validate an array of memory items one at a time, dropping (and logging)
    * any that fail validation while keeping the rest.
+   *
+   * Per-item warnings are capped at {@link MemoryClient.MAX_INVALID_ITEM_LOGS}
+   * and followed by a single summary warning with the total `invalid_count`.
    */
   private parseItems<T>(
     value: unknown,
-    schema: z.ZodType<T>,
+    schema: z.ZodType<T, unknown>,
     itemType: string,
     profileId: string
   ): T[] {
+    if (value === undefined) {
+      return [];
+    }
+
     if (!Array.isArray(value)) {
+      this.logger.warn(
+        {
+          profile_id: profileId,
+          memory_store_id: this.storeId,
+          item_type: itemType,
+          received_type: typeof value,
+        },
+        'Expected an array of memory items but received a non-array value'
+      );
       return [];
     }
 
     const parsed: T[] = [];
+    let invalidCount = 0;
     for (const [index, item] of value.entries()) {
       const result = schema.safeParse(item);
       if (result.success) {
         parsed.push(result.data);
-      } else {
+        continue;
+      }
+
+      invalidCount += 1;
+      if (invalidCount <= MemoryClient.MAX_INVALID_ITEM_LOGS) {
         this.logger.warn(
           {
             profile_id: profileId,
@@ -184,6 +208,20 @@ export class MemoryClient extends BaseClient {
         );
       }
     }
+
+    if (invalidCount > 0) {
+      this.logger.warn(
+        {
+          profile_id: profileId,
+          memory_store_id: this.storeId,
+          item_type: itemType,
+          invalid_count: invalidCount,
+          total_count: value.length,
+        },
+        'Dropped invalid memory items'
+      );
+    }
+
     return parsed;
   }
 

--- a/packages/core/src/clients/memory.ts
+++ b/packages/core/src/clients/memory.ts
@@ -1,9 +1,12 @@
+import { z } from 'zod';
 import {
   MemoryRetrievalRequest,
   MemoryRetrievalRequestSchema,
   MemoryRetrievalResponse,
-  MemoryRetrievalResponseSchema,
   EMPTY_MEMORY_RESPONSE,
+  ObservationInfoSchema,
+  SummaryInfoSchema,
+  MemoryCommunicationSchema,
   ProfileLookupResponse,
   ProfileLookupResponseSchema,
   ProfileResponse,
@@ -91,32 +94,51 @@ export class MemoryClient extends BaseClient {
         'Raw memory response received'
       );
 
-      // Validate and parse the response
-      const validatedResponse = MemoryRetrievalResponseSchema.safeParse(data);
-
-      if (!validatedResponse.success) {
+      if (data === null || typeof data !== 'object') {
         this.logger.warn(
           {
             profile_id: profileId,
             memory_store_id: this.storeId,
-            validation_errors: validatedResponse.error.issues,
           },
           'Invalid memory response format'
         );
         return EMPTY_MEMORY_RESPONSE;
       }
 
+      // Parse each item independently so a single malformed entry (e.g. an
+      // unrecognized enum value) doesn't discard the entire response.
+      const response = data as Record<string, unknown>;
+      const observations = this.parseItems(
+        response.observations,
+        ObservationInfoSchema,
+        'observation',
+        profileId
+      );
+      const summaries = this.parseItems(
+        response.summaries,
+        SummaryInfoSchema,
+        'summary',
+        profileId
+      );
+      const communications = this.parseItems(
+        response.communications,
+        MemoryCommunicationSchema,
+        'communication',
+        profileId
+      );
+
       this.logger.debug(
         {
           memory_store_id: this.storeId,
           profile_id: profileId,
-          observation_count: validatedResponse.data.observations.length,
-          summary_count: validatedResponse.data.summaries.length,
+          observation_count: observations.length,
+          summary_count: summaries.length,
+          communication_count: communications.length,
         },
         'Memory retrieval succeeded'
       );
 
-      return validatedResponse.data;
+      return { observations, summaries, communications };
     } catch (error) {
       this.logger.warn(
         {
@@ -128,6 +150,41 @@ export class MemoryClient extends BaseClient {
       );
       return EMPTY_MEMORY_RESPONSE;
     }
+  }
+
+  /**
+   * Validate an array of memory items one at a time, dropping (and logging)
+   * any that fail validation while keeping the rest.
+   */
+  private parseItems<T>(
+    value: unknown,
+    schema: z.ZodType<T>,
+    itemType: string,
+    profileId: string
+  ): T[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    const parsed: T[] = [];
+    for (const [index, item] of value.entries()) {
+      const result = schema.safeParse(item);
+      if (result.success) {
+        parsed.push(result.data);
+      } else {
+        this.logger.warn(
+          {
+            profile_id: profileId,
+            memory_store_id: this.storeId,
+            item_type: itemType,
+            item_index: index,
+            validation_errors: result.error.issues,
+          },
+          'Dropping invalid memory item'
+        );
+      }
+    }
+    return parsed;
   }
 
   /**

--- a/packages/core/src/types/memory.ts
+++ b/packages/core/src/types/memory.ts
@@ -35,7 +35,13 @@ export type MemoryChannelType = z.infer<typeof MemoryChannelTypeSchema>;
 /**
  * Participant type in Memory API
  */
-export const MemoryParticipantTypeSchema = z.enum(['HUMAN_AGENT', 'CUSTOMER', 'AI_AGENT', 'AGENT']);
+export const MemoryParticipantTypeSchema = z.enum([
+  'HUMAN_AGENT',
+  'CUSTOMER',
+  'AI_AGENT',
+  'AGENT',
+  'UNKNOWN',
+]);
 export type MemoryParticipantType = z.infer<typeof MemoryParticipantTypeSchema>;
 
 /**

--- a/tests/memory-client.test.ts
+++ b/tests/memory-client.test.ts
@@ -150,6 +150,71 @@ describe('MemoryClient', () => {
     });
   });
 
+  describe('retrieveMemories()', () => {
+    const recallUrl =
+      '/v1/Stores/mem_service_01kbjqhhdpft0tbp21jt4ktbxg/Profiles/mem_profile_00000000000000000000000001/Recall';
+
+    const makeCommunication = (id: string, authorType: string) => ({
+      id,
+      author: {
+        id: `participant_${id}`,
+        name: 'Participant',
+        address: 'someone@example.com',
+        channel: 'EMAIL',
+        type: authorType,
+      },
+      content: { text: `content ${id}` },
+      recipients: [],
+      createdAt: '2024-01-01T00:00:00Z',
+    });
+
+    it('should parse a communication whose participant type is UNKNOWN', async () => {
+      const mockResponse = {
+        observations: [],
+        summaries: [],
+        communications: [makeCommunication('comm_1', 'UNKNOWN')],
+      };
+
+      mockAdapter.onPost(recallUrl).reply(200, mockResponse);
+
+      const result = await memoryClient.retrieveMemories(
+        'mem_profile_00000000000000000000000001'
+      );
+
+      expect(result.communications).toHaveLength(1);
+      expect(result.communications[0]!.author.type).toBe('UNKNOWN');
+    });
+
+    it('should return valid items when some items fail validation', async () => {
+      const mockResponse = {
+        observations: [
+          {
+            id: 'obs_valid',
+            content: 'valid observation',
+            createdAt: '2024-01-01T00:00:00Z',
+          },
+          { id: 'obs_invalid', createdAt: 'not-a-date' },
+        ],
+        summaries: [],
+        communications: [
+          makeCommunication('comm_valid', 'CUSTOMER'),
+          { id: 'comm_invalid', author: null },
+        ],
+      };
+
+      mockAdapter.onPost(recallUrl).reply(200, mockResponse);
+
+      const result = await memoryClient.retrieveMemories(
+        'mem_profile_00000000000000000000000001'
+      );
+
+      expect(result.observations).toHaveLength(1);
+      expect(result.observations[0]!.id).toBe('obs_valid');
+      expect(result.communications).toHaveLength(1);
+      expect(result.communications[0]!.id).toBe('comm_valid');
+    });
+  });
+
   describe('region support', () => {
     it('should use region in base URL when configured', () => {
       const config = new TACConfig({ ...getTestConfig(), region: 'test-region' });

--- a/tests/memory-client.test.ts
+++ b/tests/memory-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TACConfig } from '@twilio/tac-core';
 import { MemoryClient } from '../packages/core/src/clients/memory';
 import { ProfileLookupResponse, ProfileResponse } from '@twilio/tac-core';
@@ -212,6 +212,65 @@ describe('MemoryClient', () => {
       expect(result.observations[0]!.id).toBe('obs_valid');
       expect(result.communications).toHaveLength(1);
       expect(result.communications[0]!.id).toBe('comm_valid');
+    });
+
+    it('should warn when a present field is not an array', async () => {
+      const warnSpy = vi.spyOn((memoryClient as any).logger, 'warn');
+      const mockResponse = {
+        observations: { unexpected: 'shape' },
+        summaries: [],
+        communications: [],
+      };
+
+      mockAdapter.onPost(recallUrl).reply(200, mockResponse);
+
+      const result = await memoryClient.retrieveMemories(
+        'mem_profile_00000000000000000000000001'
+      );
+
+      expect(result.observations).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          item_type: 'observation',
+          received_type: 'object',
+        }),
+        expect.stringContaining('non-array value')
+      );
+    });
+
+    it('should cap per-item warnings and emit an invalid_count summary', async () => {
+      const warnSpy = vi.spyOn((memoryClient as any).logger, 'warn');
+      const invalidObservations = Array.from({ length: 15 }, (_, i) => ({
+        id: `obs_${i}`,
+        createdAt: 'not-a-date',
+      }));
+      const mockResponse = {
+        observations: invalidObservations,
+        summaries: [],
+        communications: [],
+      };
+
+      mockAdapter.onPost(recallUrl).reply(200, mockResponse);
+
+      const result = await memoryClient.retrieveMemories(
+        'mem_profile_00000000000000000000000001'
+      );
+
+      expect(result.observations).toHaveLength(0);
+
+      const perItemWarnings = warnSpy.mock.calls.filter(
+        ([, msg]) => msg === 'Dropping invalid memory item'
+      );
+      expect(perItemWarnings).toHaveLength(10);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          item_type: 'observation',
+          invalid_count: 15,
+          total_count: 15,
+        }),
+        'Dropped invalid memory items'
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Memory recall could return empty results even when the Memory API returned valid data. Two causes:

1. `MemoryParticipantTypeSchema` omitted the `UNKNOWN` participant type that the API can return, so any recall response containing a communication with that type failed validation.
2. `MemoryClient.retrieveMemories` validated the entire response with a single `safeParse` and returned an empty response if it failed. One malformed item discarded all valid observations, summaries, and communications.

Changes:

- Add `UNKNOWN` to `MemoryParticipantTypeSchema`, matching the documented API contract and the Python SDK.
- Parse observations, summaries, and communications per-item in `retrieveMemories`. Invalid items are dropped and logged via the existing Pino logger; valid items are returned.
- Add regression tests: an `UNKNOWN` participant type parsing successfully, and a mixed valid/invalid response returning only the valid items.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

## SDK Parity

This is the **TypeScript SDK**. The Python SDK already includes the `UNKNOWN` participant type, so this brings the TypeScript SDK to parity.

- [x] Change is TypeScript-specific (no Python update needed)
- [ ] Python SDK PR created:

🤖 Generated with [Claude Code](https://claude.com/claude-code)