### PR TITLE
fix: surface participant reconciliation failures on inbound messages

### DIFF
--- a/packages/core/src/channels/messaging.ts
+++ b/packages/core/src/channels/messaging.ts
@@ -362,13 +362,19 @@ export abstract class MessagingChannel extends BaseChannel {
           // Surface via handleError (logs at error level AND fires the app's
           // onError callback) rather than a bare warn — otherwise the dropped
           // inbound is invisible to the app and can't be observed or retried.
-          this.handleError(
-            new Error(
-              `Participant reconciliation failed for conversation ${conversationId}; ` +
-                'inbound message dropped because no sendable participants could be resolved.'
-            ),
-            { conversation_id: conversationId, channel: this.channelType, dropped_inbound: true }
+          // Set a stable error.name and error_code so consumers can classify
+          // this condition programmatically without string-matching the message.
+          const error = new Error(
+            `Participant reconciliation failed for conversation ${conversationId}; ` +
+              'inbound message dropped because no sendable participants could be resolved.'
           );
+          error.name = 'ParticipantReconciliationError';
+          this.handleError(error, {
+            conversation_id: conversationId,
+            channel: this.channelType,
+            dropped_inbound: true,
+            error_code: 'participant_reconciliation_failed',
+          });
           return;
         }
 

--- a/packages/core/src/channels/messaging.ts
+++ b/packages/core/src/channels/messaging.ts
@@ -359,9 +359,15 @@ export abstract class MessagingChannel extends BaseChannel {
       if (!session.aiAgentInfo) {
         const resolved = await this.reconcileParticipants(conversationId);
         if (!resolved) {
-          this.logger.warn(
-            { conversation_id: conversationId },
-            'Reconciliation failed; skipping callback for this inbound'
+          // Surface via handleError (logs at error level AND fires the app's
+          // onError callback) rather than a bare warn — otherwise the dropped
+          // inbound is invisible to the app and can't be observed or retried.
+          this.handleError(
+            new Error(
+              `Participant reconciliation failed for conversation ${conversationId}; ` +
+                'inbound message dropped because no sendable participants could be resolved.'
+            ),
+            { conversation_id: conversationId, channel: this.channelType, dropped_inbound: true }
           );
           return;
         }

--- a/tests/reconciliation.test.ts
+++ b/tests/reconciliation.test.ts
@@ -51,8 +51,7 @@ describe('Reconcile participants', () => {
     tac = await createTestTAC(getTestConfig());
     channel = new SMSChannel(tac);
     mockAdapter = new MockAdapter(
-      (tac.getConversationClient() as unknown as { axiosInstance: typeof axios })
-        .axiosInstance
+      (tac.getConversationClient() as unknown as { axiosInstance: typeof axios }).axiosInstance
     );
 
     const memoryClient = tac.getMemoryClient() as unknown as {
@@ -82,9 +81,7 @@ describe('Reconcile participants', () => {
     ).reconcileParticipants(CONV_ID);
 
   const mockListParticipants = (participants: ConversationParticipant[]) =>
-    mockAdapter
-      .onGet(`/v2/Conversations/${CONV_ID}/Participants`)
-      .reply(200, { participants });
+    mockAdapter.onGet(`/v2/Conversations/${CONV_ID}/Participants`).reply(200, { participants });
 
   it('happy path: both sides correctly typed → no PUTs', async () => {
     const agent = participant('PA_A', 'AI_AGENT', AGENT_ADDR);
@@ -108,9 +105,7 @@ describe('Reconcile participants', () => {
     const promoted = participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR);
 
     mockListParticipants([agent, customerUnknown]);
-    mockAdapter
-      .onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_C`)
-      .reply(200, promoted);
+    mockAdapter.onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_C`).reply(200, promoted);
     // Stub lookup to miss, create to return an id.
     stubLookupProfile.mockResolvedValue({ normalizedValue: CUSTOMER_ADDR, profiles: [] });
     stubCreateProfile.mockResolvedValue('mem_profile_01new');
@@ -134,9 +129,7 @@ describe('Reconcile participants', () => {
     const promoted = participant('PA_A', 'AI_AGENT', AGENT_ADDR);
 
     mockListParticipants([agentUnknown, customer]);
-    mockAdapter
-      .onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_A`)
-      .reply(200, promoted);
+    mockAdapter.onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_A`).reply(200, promoted);
 
     const result = await callReconcile();
 
@@ -156,9 +149,7 @@ describe('Reconcile participants', () => {
     const promotedCustomer = participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR);
 
     mockListParticipants([agentUnknown, customerUnknown]);
-    mockAdapter
-      .onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_A`)
-      .reply(200, promotedAgent);
+    mockAdapter.onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_A`).reply(200, promotedAgent);
     mockAdapter
       .onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_C`)
       .reply(200, promotedCustomer);
@@ -194,9 +185,7 @@ describe('Reconcile participants', () => {
     const customer = participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR);
     const createdAgent = participant('PA_A', 'AI_AGENT', AGENT_ADDR);
     mockListParticipants([customer]);
-    mockAdapter
-      .onPost(`/v2/Conversations/${CONV_ID}/Participants`)
-      .reply(201, createdAgent);
+    mockAdapter.onPost(`/v2/Conversations/${CONV_ID}/Participants`).reply(201, createdAgent);
 
     const result = await callReconcile();
 
@@ -239,9 +228,7 @@ describe('Reconcile participants', () => {
   });
 
   it('listParticipants failure → null (skips the webhook)', async () => {
-    mockAdapter
-      .onGet(`/v2/Conversations/${CONV_ID}/Participants`)
-      .networkError();
+    mockAdapter.onGet(`/v2/Conversations/${CONV_ID}/Participants`).networkError();
 
     const result = await callReconcile();
 
@@ -255,9 +242,7 @@ describe('Reconcile participants', () => {
     const promoted = participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR);
 
     mockListParticipants([agent, customerUnknown]);
-    mockAdapter
-      .onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_C`)
-      .reply(200, promoted);
+    mockAdapter.onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_C`).reply(200, promoted);
 
     stubLookupProfile.mockResolvedValue({ normalizedValue: CUSTOMER_ADDR, profiles: [] });
     stubCreateProfile.mockResolvedValue('mem_profile_01new');
@@ -280,9 +265,7 @@ describe('Reconcile participants', () => {
     const promoted = participant('PA_C', 'CUSTOMER', CUSTOMER_ADDR);
 
     mockListParticipants([agent, customerUnknown]);
-    mockAdapter
-      .onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_C`)
-      .reply(200, promoted);
+    mockAdapter.onPut(`/v2/Conversations/${CONV_ID}/Participants/PA_C`).reply(200, promoted);
 
     // Both lookup and create fail — reconciliation still promotes, just
     // without a profileId attached.
@@ -323,7 +306,14 @@ describe('Reconcile participants', () => {
 
     expect(messageCallback).not.toHaveBeenCalled();
     expect(errors).toHaveLength(1);
+    // Stable identifiers so apps can classify this without string-matching.
+    expect(errors[0]!.error.name).toBe('ParticipantReconciliationError');
+    expect(errors[0]!.context?.error_code).toBe('participant_reconciliation_failed');
+    // Observability fields the implementation sets — assert them all so a
+    // future refactor can't silently drop the signal.
     expect(errors[0]!.context?.conversation_id).toBe(CONV_ID);
+    expect(errors[0]!.context?.dropped_inbound).toBe(true);
+    expect(errors[0]!.context?.channel).toBe(channel.channelType);
   });
 
   it('reconciliation lifts customer profileId onto session.profileId', async () => {

--- a/tests/reconciliation.test.ts
+++ b/tests/reconciliation.test.ts
@@ -298,6 +298,34 @@ describe('Reconcile participants', () => {
     expect(putBody.profileId).toBeUndefined();
   });
 
+  it('surfaces reconcile failure via onError instead of silently dropping the inbound', async () => {
+    // Reconcile fails (listParticipants unreachable) so the inbound can't be
+    // matched to sendable participants. The message is intentionally not
+    // delivered to the LLM (any reply would fail too), but the drop must be
+    // observable by the app via the error callback — not swallowed.
+    mockAdapter.onGet(`/v2/Conversations/${CONV_ID}/Participants`).networkError();
+
+    const errors: { error: Error; context?: Record<string, unknown> }[] = [];
+    channel.on('error', data => errors.push(data));
+
+    const messageCallback = vi.fn();
+    channel.on('messageReceived', messageCallback);
+
+    await channel.processWebhook({
+      eventType: 'COMMUNICATION_CREATED',
+      data: {
+        id: 'comms_communication_01test',
+        conversationId: CONV_ID,
+        content: { type: 'TEXT', text: 'hello' },
+        author: { address: CUSTOMER_ADDR, channel: 'SMS', participantId: 'PA_C' },
+      },
+    });
+
+    expect(messageCallback).not.toHaveBeenCalled();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.context?.conversation_id).toBe(CONV_ID);
+  });
+
   it('reconciliation lifts customer profileId onto session.profileId', async () => {
     // When reconcile resolves a CUSTOMER that already has a profileId
     // (set by a prior reconciliation / Conversation Memory identity-resolution), the


### PR DESCRIPTION
## Summary

Inbound messages were silently dropped when participant reconciliation failed. In `MessagingChannel.handleCommunicationCreated`, when `reconcileParticipants` returned `null` (e.g. `listParticipants` unreachable, a 409 on participant promotion, or no resolvable customer), the handler logged a bare `logger.warn` and returned early. The message never reached `onMessageReady`, and no error surfaced to the app via the channel `onError` callback — so the drop was invisible and could not be observed or reacted to.

This routes the reconcile-failure drop through the existing `handleError` mechanism instead, which logs at error level and fires the channel `onError` callback (the same path every other channel failure already uses). No new public API is introduced; the fix reuses the documented callback pattern and is backward compatible.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

## SDK Parity

This is the **TypeScript SDK**. The Python SDK has the same silent-drop behavior in `messaging.py` and should receive the equivalent fix.

- [ ] Change is TypeScript-specific (no Python update needed)
- [ ] Python SDK PR created: <!-- link to PR in twilio-agent-connect-python -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
