### PR TITLE
fix: flush pending handoff data on streaming voice responses

### DIFF
--- a/packages/core/src/channels/voice.ts
+++ b/packages/core/src/channels/voice.ts
@@ -644,21 +644,7 @@ export class VoiceChannel extends BaseChannel {
       };
 
       ws.send(JSON.stringify(response));
-
-      // If a handoff is pending, send the WS "end" message now that the
-      // LLM's final response has been delivered to the caller.
-      const session = this.getConversationSession(conversationId);
-      if (session?.pendingHandoffData) {
-        try {
-          ws.send(JSON.stringify(session.pendingHandoffData));
-          delete session.pendingHandoffData;
-        } catch (err) {
-          this.logger.warn(
-            { err, conversation_id: conversationId },
-            'WebSocket closed before sending handoff end message; caller will not be transferred'
-          );
-        }
-      }
+      this.flushPendingHandoff(conversationId, ws);
 
       return Promise.resolve();
     } catch (error) {
@@ -672,6 +658,31 @@ export class VoiceChannel extends BaseChannel {
   }
 
   /**
+   * Send the ConversationRelay `end` message if the session has a handoff
+   * pending, so the caller is transferred once the response has been delivered.
+   * No-op when nothing is pending.
+   */
+  private flushPendingHandoff(conversationId: ConversationId, ws: WebSocket): void {
+    const session = this.getConversationSession(conversationId);
+    if (!session?.pendingHandoffData) {
+      return;
+    }
+
+    try {
+      if (ws.readyState !== WebSocket.OPEN) {
+        throw new Error(`WebSocket is not open (readyState: ${ws.readyState})`);
+      }
+      ws.send(JSON.stringify(session.pendingHandoffData));
+      delete session.pendingHandoffData;
+    } catch (err) {
+      this.logger.warn(
+        { err, conversation_id: conversationId },
+        'WebSocket closed before sending handoff end message; caller will not be transferred'
+      );
+    }
+  }
+
+  /**
    * Send a streaming voice response via WebSocket, token by token.
    *
    * Each chunk from the iterable is sent as a text token message with last: false.
@@ -679,6 +690,10 @@ export class VoiceChannel extends BaseChannel {
    * only if at least one token was emitted. If the AbortSignal fires (e.g., user
    * interrupted), iteration stops and no final marker is sent (the interrupt
    * handler sends the finalization instead).
+   *
+   * Once the stream completes, a handoff pending on the session is delivered as
+   * the WS `end` message, matching {@link sendResponse}. An aborted stream
+   * leaves it pending for the next response.
    *
    * @returns The accumulated full response text.
    */
@@ -731,6 +746,12 @@ export class VoiceChannel extends BaseChannel {
 
       if (!signal?.aborted && hasSentTokens && ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ type: 'text', token: '', last: true }));
+      }
+
+      // An aborted stream was cut short, so leave any handoff pending for the
+      // next response rather than ending the call mid-utterance.
+      if (!signal?.aborted) {
+        this.flushPendingHandoff(conversationId, ws);
       }
     } catch (error) {
       this.handleError(error instanceof Error ? error : new Error(String(error)), {

--- a/tests/voice-channel.test.ts
+++ b/tests/voice-channel.test.ts
@@ -1536,6 +1536,45 @@ describe('VoiceChannel', () => {
       const hasFinalMarker = textMessages.some((m: any) => m.last === true && m.token === '');
       expect(hasFinalMarker).toBe(false);
     });
+
+    it('should send the pending handoff end message after the final token marker', async () => {
+      const { voiceChannel, mockWs } = await setupForStreaming();
+
+      const session = voiceChannel.getConversationSession('CHstream_test' as any)!;
+      session.pendingHandoffData = {
+        type: 'end',
+        handoffData: JSON.stringify({ conversationId: 'CHstream_test' }),
+      };
+
+      await voiceChannel.sendStreamingResponse(
+        'CHstream_test' as any,
+        makeTokenStream(['Transferring', ' you', ' now'])
+      );
+
+      const messages = mockWs.send.mock.calls.map((call: any[]) => JSON.parse(call[0] as string));
+      const endIndex = messages.findIndex((m: any) => m.type === 'end');
+      const finalMarkerIndex = messages.findIndex(
+        (m: any) => m.type === 'text' && m.last === true && m.token === ''
+      );
+
+      expect(endIndex).toBeGreaterThan(-1);
+      expect(messages[endIndex].handoffData).toBe(
+        JSON.stringify({ conversationId: 'CHstream_test' })
+      );
+      expect(endIndex).toBeGreaterThan(finalMarkerIndex);
+      expect(session.pendingHandoffData).toBeUndefined();
+    });
+
+    it('should not send an end message when no handoff is pending', async () => {
+      const { voiceChannel, mockWs } = await setupForStreaming();
+
+      await voiceChannel.sendStreamingResponse('CHstream_test' as any, makeTokenStream(['Hello']));
+
+      const hasEnd = mockWs.send.mock.calls.some(
+        (call: any[]) => JSON.parse(call[0] as string).type === 'end'
+      );
+      expect(hasEnd).toBe(false);
+    });
   });
 
   describe('interrupt handling', () => {
@@ -1709,6 +1748,59 @@ describe('VoiceChannel', () => {
       });
 
       expect(ackCall).toBeUndefined();
+    });
+
+    it('should keep a pending handoff across an interrupt and flush it on the next response', async () => {
+      const { voiceChannel, mockWs } = await setupForInterrupt();
+
+      const session = voiceChannel.getConversationSession('CHinterrupt_test' as any)!;
+      session.pendingHandoffData = {
+        type: 'end',
+        handoffData: JSON.stringify({ conversationId: 'CHinterrupt_test' }),
+      };
+
+      voiceChannel
+        .sendStreamingResponse(
+          'CHinterrupt_test' as any,
+          (async function* () {
+            yield 'Transferring';
+            yield new Promise(() => {}) as never;
+          })()
+        )
+        .catch(() => {});
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      mockWs._emit(
+        'message',
+        Buffer.from(JSON.stringify({ type: 'interrupt', utteranceUntilInterrupt: 'Transferring' }))
+      );
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // The interrupted response was never fully delivered, so the handoff must
+      // stay pending rather than ending the call early.
+      expect(session.pendingHandoffData).toBeDefined();
+      expect(
+        mockWs.send.mock.calls.some((call: any[]) => JSON.parse(call[0] as string).type === 'end')
+      ).toBe(false);
+
+      mockWs.send.mockClear();
+
+      await voiceChannel.sendStreamingResponse(
+        'CHinterrupt_test' as any,
+        (async function* () {
+          yield 'Goodbye';
+        })()
+      );
+
+      const endMessage = mockWs.send.mock.calls
+        .map((call: any[]) => JSON.parse(call[0] as string))
+        .find((m: any) => m.type === 'end');
+
+      expect(endMessage).toBeDefined();
+      expect(endMessage.handoffData).toBe(JSON.stringify({ conversationId: 'CHinterrupt_test' }));
+      expect(session.pendingHandoffData).toBeUndefined();
     });
 
     it('should pass utteranceUntilInterrupt through onInterrupt callback', async () => {

--- a/tests/voice-channel.test.ts
+++ b/tests/voice-channel.test.ts
@@ -1558,6 +1558,7 @@ describe('VoiceChannel', () => {
       );
 
       expect(endIndex).toBeGreaterThan(-1);
+      expect(finalMarkerIndex).toBeGreaterThan(-1);
       expect(messages[endIndex].handoffData).toBe(
         JSON.stringify({ conversationId: 'CHstream_test' })
       );


### PR DESCRIPTION
## Summary

`VoiceChannel.sendStreamingResponse()` never flushed `session.pendingHandoffData`, so the ConversationRelay `end` message was not sent when an app streamed its final response. The caller was not transferred and the `handoffData` payload — including the `conversationSid` apps read at the `<Connect action>` URL — never arrived. `sendResponse()` already flushed it, so the two send paths behaved differently for identical session state.

Reported by a customer who hit it after adopting streaming; their workaround was a hardcoded `sendResponse()` before the call ended.

The flush is now `flushPendingHandoff()`, called from both `sendResponse()` and `sendStreamingResponse()`.

### Interrupt behavior

An aborted stream deliberately does **not** flush. The response was cut short, so ending the call there would drop the caller mid-utterance. `pendingHandoffData` stays on the session and the next `sendResponse()`/`sendStreamingResponse()` delivers it — no payload is lost. A test covers this path.

### Streaming and tool-call ordering

The customer also observed that with streaming, the handoff tool runs *after* the text has been streamed. That is inherent to streaming LLM APIs — tool calls arrive at the end of a completion — and is not addressed here. The resolution is in the app's agent loop: execute the tool, submit the result, then stream the model's follow-up as a separate turn. With this fix that second call delivers the `end` message right after the last token, restoring the pre-streaming sequence without a hardcoded `sendResponse()`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [ ] Tested E2E

Three tests in `tests/voice-channel.test.ts`, written to fail before the fix:

- streaming sends the `end` message after the final `{last: true}` marker and clears `pendingHandoffData`
- no `end` message when no handoff is pending
- a pending handoff survives an interrupt and is flushed by the next response

TSDoc on `sendStreamingResponse()` now states the flush behavior. The contract documented in `packages/tools/src/built-in/handoff.ts` ("the voice channel automatically sends the WS `end` message with `handoffData` after the LLM's final response is delivered") is unqualified and now holds for both paths.

## SDK Parity

This is the **TypeScript SDK**. If this change affects shared functionality, ensure the [Python SDK](https://github.com/twilio/twilio-agent-connect-python) is updated as well.

> **Tip:** Use the `/sync-to-python-sdk` skill in Claude Code to automatically generate and create a Python SDK PR from your changes.

- [x] Change is TypeScript-specific (no Python update needed)
- [ ] Python SDK PR created: <!-- link to PR in twilio-agent-connect-python -->

Python is already correct — it has a single `send_response()` that branches on `str` vs `AsyncGenerator` with the flush placed after both branches (`src/tac/channels/voice/channel.py:819-834`). This was a TypeScript-only divergence introduced by splitting the two paths into separate public methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
