### PR TITLE
feat: add composable guardrails for TACTool (rate limiting)

### DIFF
--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -24,3 +24,6 @@ export {
   createKnowledgeSearchToolAsync,
   createKnowledgeTools,
 } from './built-in/knowledge';
+
+// Guardrails
+export { GuardrailError } from './lib/errors';

--- a/packages/tools/src/lib/errors.ts
+++ b/packages/tools/src/lib/errors.ts
@@ -1,0 +1,9 @@
+export class GuardrailError extends Error {
+  constructor(
+    message: string,
+    public readonly type: 'rate_limit' | 'content_filter'
+  ) {
+    super(message);
+    this.name = 'GuardrailError';
+  }
+}

--- a/packages/tools/src/lib/rate-limiter.ts
+++ b/packages/tools/src/lib/rate-limiter.ts
@@ -1,0 +1,30 @@
+import { GuardrailError } from './errors.js';
+
+export interface RateLimitConfig<TParams> {
+  maxCalls: number;
+  windowMs: number;
+  keyFn?: (params: TParams) => string;
+}
+
+export class SlidingWindowRateLimiter<TParams> {
+  private readonly timestamps: Map<string, number[]> = new Map();
+
+  constructor(private readonly config: RateLimitConfig<TParams>) {}
+
+  check(toolName: string, params: TParams): void {
+    const key = this.config.keyFn ? this.config.keyFn(params) : toolName;
+    const now = Date.now();
+    const cutoff = now - this.config.windowMs;
+    const calls = (this.timestamps.get(key) ?? []).filter(t => t > cutoff);
+
+    if (calls.length >= this.config.maxCalls) {
+      throw new GuardrailError(
+        `Rate limit exceeded: max ${this.config.maxCalls} calls per ${this.config.windowMs}ms`,
+        'rate_limit'
+      );
+    }
+
+    calls.push(now);
+    this.timestamps.set(key, calls);
+  }
+}

--- a/tests/guardrails.test.ts
+++ b/tests/guardrails.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { GuardrailError } from '@twilio/tac-tools';
+
+describe('GuardrailError', () => {
+  it('is an instance of Error', () => {
+    const err = new GuardrailError('blocked', 'rate_limit');
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('has name GuardrailError', () => {
+    const err = new GuardrailError('blocked', 'rate_limit');
+    expect(err.name).toBe('GuardrailError');
+  });
+
+  it('exposes the type field', () => {
+    expect(new GuardrailError('x', 'rate_limit').type).toBe('rate_limit');
+    expect(new GuardrailError('x', 'content_filter').type).toBe('content_filter');
+  });
+
+  it('sets the message', () => {
+    const err = new GuardrailError('too many calls', 'rate_limit');
+    expect(err.message).toBe('too many calls');
+  });
+});

--- a/tests/rate-limiter.test.ts
+++ b/tests/rate-limiter.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SlidingWindowRateLimiter } from '../packages/tools/src/lib/rate-limiter.js';
+import { GuardrailError } from '@twilio/tac-tools';
+
+describe('SlidingWindowRateLimiter', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('allows calls under the limit', () => {
+    const limiter = new SlidingWindowRateLimiter<Record<string, never>>({ maxCalls: 3, windowMs: 1000 });
+    expect(() => limiter.check('tool', {})).not.toThrow();
+    expect(() => limiter.check('tool', {})).not.toThrow();
+    expect(() => limiter.check('tool', {})).not.toThrow();
+  });
+
+  it('blocks the (maxCalls+1)th call within the window', () => {
+    const limiter = new SlidingWindowRateLimiter<Record<string, never>>({ maxCalls: 3, windowMs: 1000 });
+    limiter.check('tool', {});
+    limiter.check('tool', {});
+    limiter.check('tool', {});
+    expect(() => limiter.check('tool', {})).toThrow(GuardrailError);
+  });
+
+  it('thrown GuardrailError has type rate_limit', () => {
+    const limiter = new SlidingWindowRateLimiter<Record<string, never>>({ maxCalls: 1, windowMs: 1000 });
+    limiter.check('tool', {});
+    let caught: unknown;
+    try { limiter.check('tool', {}); } catch (e) { caught = e; }
+    expect(caught).toBeInstanceOf(GuardrailError);
+    expect((caught as GuardrailError).type).toBe('rate_limit');
+  });
+
+  it('resets after the window expires', () => {
+    const limiter = new SlidingWindowRateLimiter<Record<string, never>>({ maxCalls: 2, windowMs: 1000 });
+    limiter.check('tool', {});
+    limiter.check('tool', {});
+    vi.advanceTimersByTime(1001);
+    expect(() => limiter.check('tool', {})).not.toThrow();
+  });
+
+  it('tracks different keys independently', () => {
+    const limiter = new SlidingWindowRateLimiter<{ key: string }>({
+      maxCalls: 1,
+      windowMs: 1000,
+      keyFn: p => p.key,
+    });
+    limiter.check('tool', { key: 'a' });
+    expect(() => limiter.check('tool', { key: 'b' })).not.toThrow();
+  });
+
+  it('blocks same key after limit', () => {
+    const limiter = new SlidingWindowRateLimiter<{ key: string }>({
+      maxCalls: 1,
+      windowMs: 1000,
+      keyFn: p => p.key,
+    });
+    limiter.check('tool', { key: 'a' });
+    expect(() => limiter.check('tool', { key: 'a' })).toThrow(GuardrailError);
+  });
+
+  it('calls keyFn with actual params', () => {
+    const keyFn = vi.fn((_p: { msg: string }) => 'k');
+    const limiter = new SlidingWindowRateLimiter({ maxCalls: 5, windowMs: 1000, keyFn });
+    const params = { msg: 'hello' };
+    limiter.check('tool', params);
+    expect(keyFn).toHaveBeenCalledWith(params);
+  });
+
+  it('defaults key to tool name when keyFn omitted', () => {
+    const limiter = new SlidingWindowRateLimiter<Record<string, never>>({ maxCalls: 1, windowMs: 1000 });
+    limiter.check('my_tool', {});
+    expect(() => limiter.check('my_tool', {})).toThrow(GuardrailError);
+    // different tool name = different key, should not throw
+    expect(() => limiter.check('other_tool', {})).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a composable guardrail system to `packages/tools` that lets developers wrap any `TACTool` with rate limiting before the tool's implementation runs. This is the foundation for a broader guardrail system (content filtering + `withGuardrails()` wrapper coming in a follow-up PR).

**New files:**
- `packages/tools/src/lib/errors.ts` — `GuardrailError` with a `type` field (`'rate_limit' | 'content_filter'`)
- `packages/tools/src/lib/rate-limiter.ts` — `SlidingWindowRateLimiter` (sliding window, in-memory, per-key)

**Modified:**
- `packages/tools/src/index.ts` — exports `GuardrailError` publicly

**Usage preview** (once `withGuardrails()` lands in the follow-up):
```ts
import { createSendMessageTool, withGuardrails } from 'twilio-agent-connect';

const safeSendMessage = withGuardrails(
  createSendMessageTool(channel, conversationId),
  {
    rateLimit: {
      maxCalls: 5,
      windowMs: 60_000,
      keyFn: () => conversationId, // per-conversation limit
    },
  }
);
```

When the limit is exceeded, `GuardrailError` is thrown — LLM SDKs surface this as a tool-result message so the model can respond gracefully ("I've sent too many messages, please wait a moment").

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

## SDK Parity

- [x] Change is TypeScript-specific (no Python update needed)