### PR TITLE
Allow a base path in TWILIO_VOICE_PUBLIC_DOMAIN (Python SDK parity)

### DIFF
--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -82,7 +82,7 @@ See [`examples/.env.example`](examples/.env.example) for all available configura
 
 ### Optional (Server)
 
-- `TWILIO_VOICE_PUBLIC_DOMAIN`: Your ngrok domain without `https://` prefix (required for voice, e.g., `abc123.ngrok.app`). May include a base path if the app is served under one (e.g., `example.com/server1`).
+- `TWILIO_VOICE_PUBLIC_DOMAIN`: Public host for voice routes (required for voice, e.g., `abc123.ngrok.app`). May include a port and/or base path (e.g., `example.ngrok.app:8080` or `example.com/server1`). Schemes like `https://` and trailing slashes are stripped automatically.
 - `TWILIO_WHATSAPP_NUMBER`: Your Twilio WhatsApp number (required for WhatsApp channel, e.g., `whatsapp:+1234567890`)
 
 ### Optional (Handoff)

--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -82,7 +82,7 @@ See [`examples/.env.example`](examples/.env.example) for all available configura
 
 ### Optional (Server)
 
-- `TWILIO_VOICE_PUBLIC_DOMAIN`: Your ngrok domain without `https://` prefix (required for voice, e.g., `abc123.ngrok.app`)
+- `TWILIO_VOICE_PUBLIC_DOMAIN`: Your ngrok domain without `https://` prefix (required for voice, e.g., `abc123.ngrok.app`). May include a base path if the app is served under one (e.g., `example.com/server1`).
 - `TWILIO_WHATSAPP_NUMBER`: Your Twilio WhatsApp number (required for WhatsApp channel, e.g., `whatsapp:+1234567890`)
 
 ### Optional (Handoff)

--- a/packages/core/src/lib/config.ts
+++ b/packages/core/src/lib/config.ts
@@ -97,7 +97,7 @@ export class TACConfig {
    * Optional environment variables:
    * - TWILIO_WHATSAPP_NUMBER: WhatsApp number for WhatsApp channel (e.g., 'whatsapp:+1234567890')
    * - TWILIO_CONVERSATION_CONFIGURATION_ID: Conversation Orchestrator configuration ID (enables orchestrated mode)
-   * - TWILIO_VOICE_PUBLIC_DOMAIN: Public domain for voice routes (required for voice; a base path is allowed, e.g., 'abc123.ngrok.app' or 'example.com/server1')
+   * - TWILIO_VOICE_PUBLIC_DOMAIN: Public domain for voice routes (required for voice; a port and/or base path are allowed, e.g., 'abc123.ngrok.app', 'example.ngrok.app:8080', or 'example.com/server1')
    * - TWILIO_VOICE_WEBSOCKET_PATH: Path for the voice WebSocket (default: /ws)
    * - TWILIO_VOICE_ACTION_PATH: Path for the ConversationRelay action callback (default: /conversation-relay-callback)
    * - TWILIO_REGION: Twilio region subdomain for API routing (e.g. transforms base URLs to `https://{product}.{region}.twilio.com`)

--- a/packages/core/src/lib/config.ts
+++ b/packages/core/src/lib/config.ts
@@ -97,7 +97,7 @@ export class TACConfig {
    * Optional environment variables:
    * - TWILIO_WHATSAPP_NUMBER: WhatsApp number for WhatsApp channel (e.g., 'whatsapp:+1234567890')
    * - TWILIO_CONVERSATION_CONFIGURATION_ID: Conversation Orchestrator configuration ID (enables orchestrated mode)
-   * - TWILIO_VOICE_PUBLIC_DOMAIN: Public domain for voice routes (required for voice; domain only, without protocol/port/path, e.g., 'abc123.ngrok.app')
+   * - TWILIO_VOICE_PUBLIC_DOMAIN: Public domain for voice routes (required for voice; a base path is allowed, e.g., 'abc123.ngrok.app' or 'example.com/server1')
    * - TWILIO_VOICE_WEBSOCKET_PATH: Path for the voice WebSocket (default: /ws)
    * - TWILIO_VOICE_ACTION_PATH: Path for the ConversationRelay action callback (default: /conversation-relay-callback)
    * - TWILIO_REGION: Twilio region subdomain for API routing (e.g. transforms base URLs to `https://{product}.{region}.twilio.com`)

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -66,10 +66,10 @@ export const TACConfigSchema = z.object({
     .regex(/^conv_configuration_[0-9a-z]{26}$/, 'Invalid Conversation Configuration ID format')
     .optional(),
   /**
-   * Public base URL where voice routes are reachable (e.g. "example.ngrok.app",
-   * or "example.com/server1" when served under a base path). Used by
-   * VoiceChannel to construct the public WebSocket URL and ConversationRelay
-   * action URL. Required when using the Voice channel.
+   * Public domain where voice routes are reachable, optionally including a port
+   * and/or base path (e.g. "example.ngrok.app", "example.ngrok.app:8080",
+   * or "example.com/server1"). Used by VoiceChannel to construct the public
+   * WebSocket URL and ConversationRelay action URL. Required when using the Voice channel.
    *
    * Whitespace, schemes (https://, wss://), and trailing slashes are stripped
    * automatically; anything else is passed through as given. Mirrors the Python

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -66,39 +66,29 @@ export const TACConfigSchema = z.object({
     .regex(/^conv_configuration_[0-9a-z]{26}$/, 'Invalid Conversation Configuration ID format')
     .optional(),
   /**
-   * Public domain where voice routes are reachable (e.g. "abc123.ngrok.app").
-   * Used by VoiceChannel to construct the public WebSocket URL and
-   * ConversationRelay action URL. Required when using the Voice channel.
+   * Public base URL where voice routes are reachable (e.g. "example.ngrok.app",
+   * or "example.com/server1" when served under a base path). Used by
+   * VoiceChannel to construct the public WebSocket URL and ConversationRelay
+   * action URL. Required when using the Voice channel.
    *
-   * Schemes (https://, wss://), surrounding whitespace, and trailing slashes
-   * are stripped automatically before validation — a naive copy-paste from a
-   * browser address bar like "https://example.ngrok.app/" is normalized to
-   * "example.ngrok.app" rather than rejected.
+   * Whitespace, schemes (https://, wss://), and trailing slashes are stripped
+   * automatically; anything else is passed through as given. Mirrors the Python
+   * SDK's `_normalize_voice_public_domain` — keep the two in step.
    */
   voicePublicDomain: z
-    .preprocess(
-      v => {
-        if (typeof v !== 'string') return v;
-        let s = v.trim();
-        if (s.length === 0) return undefined;
-        for (const scheme of ['https://', 'http://', 'wss://', 'ws://']) {
-          if (s.toLowerCase().startsWith(scheme)) {
-            s = s.slice(scheme.length);
-            break;
-          }
+    .preprocess(v => {
+      if (typeof v !== 'string') return v;
+      let s = v.trim();
+      if (s.length === 0) return undefined;
+      for (const scheme of ['https://', 'http://', 'wss://', 'ws://']) {
+        if (s.toLowerCase().startsWith(scheme)) {
+          s = s.slice(scheme.length);
+          break;
         }
-        s = s.replace(/\/+$/, '');
-        return s.length === 0 ? undefined : s;
-      },
-      z
-        .string()
-        .max(253, 'Hostname too long (max 253 characters)')
-        .regex(
-          /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/,
-          'Invalid hostname format. Must be a hostname without protocol, port, or path (e.g., "abc123.ngrok.app", "localhost", or "192.168.1.100")'
-        )
-        .optional()
-    )
+      }
+      s = s.replace(/\/+$/, '');
+      return s.length === 0 ? undefined : s;
+    }, z.string().optional())
     .optional(),
 
   /**

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -184,15 +184,6 @@ describe('TACConfig', () => {
       expect(config.voicePublicDomain).toBe('example.ngrok.app');
     });
 
-    it('should reject invalid voicePublicDomain format', () => {
-      setRequiredEnvVars();
-      process.env.TWILIO_VOICE_PUBLIC_DOMAIN = 'not a valid domain!';
-
-      expect(() => {
-        TACConfig.fromEnv();
-      }).toThrow(/Invalid hostname format/);
-    });
-
     it('should strip an http:// protocol from voicePublicDomain', () => {
       setRequiredEnvVars();
       process.env.TWILIO_VOICE_PUBLIC_DOMAIN = 'http://example.ngrok.app';
@@ -220,33 +211,41 @@ describe('TACConfig', () => {
       expect(config.voicePublicDomain).toBe('example.ngrok.app');
     });
 
-    it('should reject voicePublicDomain with path', () => {
+    it('should accept voicePublicDomain with a base path', () => {
       setRequiredEnvVars();
-      process.env.TWILIO_VOICE_PUBLIC_DOMAIN = 'example.ngrok.app/path';
+      process.env.TWILIO_VOICE_PUBLIC_DOMAIN = 'example.ngrok.app/server1';
 
-      expect(() => {
-        TACConfig.fromEnv();
-      }).toThrow(/Invalid hostname format/);
+      const config = TACConfig.fromEnv();
+
+      expect(config.voicePublicDomain).toBe('example.ngrok.app/server1');
     });
 
-    it('should reject voicePublicDomain with port', () => {
+    it('should accept a multi-segment base path and strip scheme and trailing slash', () => {
+      setRequiredEnvVars();
+      process.env.TWILIO_VOICE_PUBLIC_DOMAIN = 'https://example.com/a/b/';
+
+      const config = TACConfig.fromEnv();
+
+      expect(config.voicePublicDomain).toBe('example.com/a/b');
+    });
+
+    it('should accept voicePublicDomain with a port', () => {
       setRequiredEnvVars();
       process.env.TWILIO_VOICE_PUBLIC_DOMAIN = 'example.ngrok.app:8080';
 
-      expect(() => {
-        TACConfig.fromEnv();
-      }).toThrow(/Invalid hostname format/);
+      const config = TACConfig.fromEnv();
+
+      expect(config.voicePublicDomain).toBe('example.ngrok.app:8080');
     });
 
-    it('should reject voicePublicDomain that is too long', () => {
+    it('should normalize rather than validate voicePublicDomain (Python SDK parity)', () => {
+      // Don't reintroduce a hostname pattern here without changing Python too.
       setRequiredEnvVars();
-      // Create a domain longer than 253 characters
-      const longDomain = 'a'.repeat(250) + '.com';
-      process.env.TWILIO_VOICE_PUBLIC_DOMAIN = longDomain;
+      process.env.TWILIO_VOICE_PUBLIC_DOMAIN = '  https://internal_host.corp:8443/a/b/  ';
 
-      expect(() => {
-        TACConfig.fromEnv();
-      }).toThrow(/Hostname too long/);
+      const config = TACConfig.fromEnv();
+
+      expect(config.voicePublicDomain).toBe('internal_host.corp:8443/a/b');
     });
 
     it('should accept valid subdomain', () => {


### PR DESCRIPTION
## Summary

`TACConfig` rejected a path-suffixed public domain such as `mark.server/server1`, which some customers use as their base URL — reported in #help-tac. The hostname regex also rejected ports (`example.ngrok.app:8080`).

**The Python SDK never had this validation.** Its `_normalize_voice_public_domain` strips whitespace, schemes, and trailing slashes and accepts whatever remains, so `mark.server/server1` already works there — this was a TypeScript-only divergence. Rather than write a looser TS-specific pattern, this drops the regex and length cap so the TS preprocess is a line-for-line translation of the Python validator.

**Verified to match Python exactly**: both SDKs were run over the same 30 inputs — schemes in mixed case, `https://` alone, `///`, `/`, whitespace-only values, double trailing slashes, `http://https://x.com`, ports, multi-segment paths, and non-domain garbage — with zero differences in output. (The one remaining divergence is outside the string domain: a non-string value raises `AttributeError` in Python vs a Zod type error in TS. Both reject.)

Net effect:

```
TWILIO_VOICE_PUBLIC_DOMAIN=example.com/server1
  → wss://example.com/server1/ws
  → https://example.com/server1/conversation-relay-callback
```

### Not included

The same thread raised reverse proxies: a path-stripping proxy rewrites the request path before it reaches Fastify, so webhook signature validation fails even with this fix. That's a separate, larger problem — it affects messaging channels too, needs the same treatment in Python (which also ignores ASGI's `root_path`), and is probably best solved by a single first-class "public base URL" concept rather than header sniffing. Deliberately out of scope here.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [ ] Tested E2E

Rejection tests replaced with acceptance/parity tests, including one that pins the normalize-don't-validate contract so a hostname pattern doesn't get reintroduced in one SDK only. 642 tests pass; typecheck, lint, and format clean.

## SDK Parity

This is the **TypeScript SDK**. If this change affects shared functionality, ensure the [Python SDK](https://github.com/twilio/twilio-agent-connect-python) is updated as well.

- [x] Change is TypeScript-specific (no Python update needed) — it *removes* a TS-only divergence; Python already behaves this way
- [ ] Python SDK PR created:

🤖 Generated with [Claude Code](https://claude.com/claude-code)
