### PR TITLE
perf(memory): skip query expansion for once-mode recall

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,8 @@ const voiceChannel = new VoiceChannel(tac, { memoryMode: 'never' }); // default
 
 - **`"never"` (default)**: No automatic fetching. Use `tac.retrieveMemory()` in callbacks for conditional retrieval.
 - **`"always"`**: Automatically fetches memory (using the message as query) for every inbound message. Available in `onMessageReady` callback's `memory` parameter.
-- **`"once"`**: Fetches memory once at conversation start with an empty query and caches it on the session. Subsequent messages reuse the cache until the conversation becomes INACTIVE (Conversation Orchestrator refreshes memory on that transition), after which the next message re-fetches.
+- **`"once"`**: Fetches memory once at conversation start with no query and caches it on the session. Subsequent messages reuse the cache until the conversation becomes INACTIVE (Conversation Orchestrator refreshes memory on that transition), after which the next message re-fetches. The fetch also omits `conversationId`: with no query it would only trigger Memory's server-side query expansion (an LLM call — 1854ms vs 28ms measured), so results come back by recency. `"always"` still sends it.
+- `memoryConfig.communicationsLimit` therefore defaults to **0**, as in the Memory API and Python SDK. Above 0, Memory requires `conversationId` on every `/Recall`, so raising it makes `"once"` fetches fail with a 400 and fall back to the Conversations API.
 
 ## Pull Requests
 

--- a/getting_started/examples/openai-streaming/src/index.ts
+++ b/getting_started/examples/openai-streaming/src/index.ts
@@ -10,22 +10,26 @@
 import { config } from 'dotenv';
 import { Agent, run } from '@openai/agents';
 import type { AgentInputItem } from '@openai/agents';
-import { TAC, TACConfig, VoiceChannel, SMSChannel, TACServer } from 'twilio-agent-connect';
+import {
+  TAC,
+  TACConfig,
+  VoiceChannel,
+  SMSChannel,
+  TACServer,
+  MemoryPromptBuilder,
+} from 'twilio-agent-connect';
 
 config({ path: '../.env' });
 
-const agent = new Agent({
-  name: 'customer-service',
-  instructions:
-    'You are a customer service agent speaking with a user over voice or SMS. ' +
-    'Keep responses short and conversational — a sentence or two. ' +
-    'Do not use markdown, asterisks, bullets, or emojis; your words will be ' +
-    'spoken aloud or sent as plain text.',
-  model: 'gpt-5.4-mini',
-});
+const AGENT_INSTRUCTIONS =
+  'You are a customer service agent speaking with a user over voice or SMS. ' +
+  'Keep responses short and conversational — a sentence or two. ' +
+  'Do not use markdown, asterisks, bullets, or emojis; your words will be ' +
+  'spoken aloud or sent as plain text.';
 
 const tac = await TAC.create({ config: TACConfig.fromEnv() });
-const voiceChannel = new VoiceChannel(tac);
+// "once" caches memory per conversation, keeping /Recall off the per-turn path.
+const voiceChannel = new VoiceChannel(tac, { memoryMode: 'once' });
 const smsChannel = new SMSChannel(tac);
 
 tac.registerChannel(voiceChannel);
@@ -33,7 +37,7 @@ tac.registerChannel(smsChannel);
 
 const conversationHistory: Record<string, AgentInputItem[]> = {};
 
-tac.onMessageReady(async ({ conversationId, message, channel, abortSignal }) => {
+tac.onMessageReady(async ({ conversationId, message, memory, session, channel, abortSignal }) => {
   const convId = conversationId as string;
 
   try {
@@ -45,6 +49,13 @@ tac.onMessageReady(async ({ conversationId, message, channel, abortSignal }) => 
       type: 'message',
       role: 'user',
       content: message,
+    });
+
+    // Fold the retrieved memory and profile traits into this turn's prompt.
+    const agent = new Agent({
+      name: 'customer-service',
+      instructions: MemoryPromptBuilder.compose(AGENT_INSTRUCTIONS, memory, session),
+      model: 'gpt-5.4-mini',
     });
 
     if (channel === 'voice') {

--- a/packages/core/src/channels/base.ts
+++ b/packages/core/src/channels/base.ts
@@ -33,7 +33,7 @@ export interface BaseChannelOptions {
    *
    * - "never": Memory is not automatically retrieved. Use the memory TAC tool or manually call `tac.retrieveMemory()` in callbacks for conditional retrieval.
    * - "always": Memory is automatically retrieved (using the message as query) for every inbound message and available in `onMessageReady` callback.
-   * - "once": Memory is retrieved once at conversation start with an empty query and cached on the session. Subsequent messages reuse the cache until the conversation becomes INACTIVE.
+   * - "once": Memory is retrieved once at conversation start with no query (and no conversation id) and cached on the session. Subsequent messages reuse the cache until the conversation becomes INACTIVE.
    */
   memoryMode?: MemoryMode;
 
@@ -417,9 +417,9 @@ export abstract class BaseChannel {
    *
    * Modes:
    * - "always": Fetch with the provided query on every message.
-   * - "once": Fetch once with an empty query and cache the result on the
-   *   session. Subsequent calls reuse the cache until it is invalidated on the
-   *   INACTIVE transition.
+   * - "once": Fetch once with neither a query nor a conversation id (skipping
+   *   query expansion) and cache the result on the session. Subsequent calls
+   *   reuse the cache until it is invalidated on the INACTIVE transition.
    * - "never": Skip retrieval.
    *
    * Memory retrieval failures are logged and swallowed so message processing
@@ -441,10 +441,14 @@ export abstract class BaseChannel {
     }
 
     try {
-      // "always" uses the message as query; "once" fetches with an empty query.
+      // "always" sends query + conversation id so Memory ranks by relevance.
+      // "once" sends neither: with no query, a conversation id only buys
+      // Memory's expensive server-side query expansion.
+      const isAlways = this.memoryMode === 'always';
       const memory = await this.tac.retrieveMemory(
         session,
-        this.memoryMode === 'always' ? query : undefined
+        isAlways ? query : undefined,
+        isAlways ? session.conversationId : undefined
       );
       if (this.memoryMode === 'once') {
         session.cachedMemory = memory;

--- a/packages/core/src/clients/memory.ts
+++ b/packages/core/src/clients/memory.ts
@@ -136,6 +136,8 @@ export class MemoryClient extends BaseClient {
           observation_count: observations.length,
           summary_count: summaries.length,
           communication_count: communications.length,
+          // Server-side query time; dominates /Recall when expansion runs.
+          query_time_ms: (response.meta as { queryTime?: number } | undefined)?.queryTime,
         },
         'Memory retrieval succeeded'
       );

--- a/packages/core/src/lib/tac.ts
+++ b/packages/core/src/lib/tac.ts
@@ -493,6 +493,10 @@ export class TAC {
    *
    * @param session - Conversation session context
    * @param query - Optional semantic search query
+   * @param conversationId - Passed through to `/Recall` as-is. Sending one
+   *   without a `query` makes Memory infer one from that conversation's history
+   *   — an expensive server-side step — so leave it unset when there is no
+   *   per-turn topic (e.g. `"once"` mode's cache-priming fetch).
    * @returns Promise containing TACMemoryResponse wrapper providing unified access to memory data.
    *
    * Attempts to retrieve from Memory API first:
@@ -505,7 +509,8 @@ export class TAC {
    */
   public async retrieveMemory(
     session: ConversationSession,
-    query?: string
+    query?: string,
+    conversationId?: string
   ): Promise<TACMemoryResponse> {
     if (!this.isOrchestratorEnabled()) {
       return new TACMemoryResponse([]);
@@ -575,7 +580,7 @@ export class TAC {
       }
 
       const memoryResponse = await this.memoryClient.retrieveMemories(session.profileId, {
-        conversationId: session.conversationId,
+        conversationId,
         query,
         observationsLimit: this.config.memoryConfig.observationsLimit,
         summariesLimit: this.config.memoryConfig.summariesLimit,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -13,8 +13,10 @@ export const TwilioMemoryConfigSchema = z.object({
   traitGroups: z.array(z.string()).optional(),
   observationsLimit: z.number().int().min(0).max(100).default(20),
   summariesLimit: z.number().int().min(0).max(100).default(5),
-  // API default is 0 (no communications fetched). SDK defaults to 10 for a useful out-of-box experience.
-  communicationsLimit: z.number().int().min(0).max(100).default(10),
+  // 0 matches the Memory API and Python SDK. Above 0, Memory requires a
+  // conversationId on every /Recall, forcing the query expansion that
+  // `memoryMode: "once"` exists to avoid.
+  communicationsLimit: z.number().int().min(0).max(100).default(0),
   relevanceThreshold: z.number().min(0.0).max(1.0).default(0.0),
   /**
    * Trait group name that holds the phone identifier on newly created profiles.

--- a/packages/core/src/types/memory.ts
+++ b/packages/core/src/types/memory.ts
@@ -4,8 +4,9 @@ import { z } from 'zod';
  * Memory retrieval mode for channels.
  *
  * - "always": Fetch memory with the message as query on every inbound message.
- * - "once": Fetch memory once at conversation start with an empty query and
- *   cache it. The cache is invalidated when the conversation becomes INACTIVE.
+ * - "once": Fetch memory once at conversation start with no query (and no
+ *   conversation id, skipping query expansion) and cache it. The cache is
+ *   invalidated when the conversation becomes INACTIVE.
  * - "never": Never automatically fetch memory (default).
  */
 export const MemoryModeSchema = z.enum(['always', 'never', 'once']);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -482,7 +482,8 @@ describe('TACConfig', () => {
 
       expect(config.memoryConfig.observationsLimit).toBe(20);
       expect(config.memoryConfig.summariesLimit).toBe(5);
-      expect(config.memoryConfig.communicationsLimit).toBe(10);
+      // Must stay 0: above 0, Memory rejects the /Recall "once" mode sends.
+      expect(config.memoryConfig.communicationsLimit).toBe(0);
       expect(config.memoryConfig.relevanceThreshold).toBe(0.0);
       expect(config.memoryConfig.traitGroups).toBeUndefined();
     });

--- a/tests/memory-mode-once.test.ts
+++ b/tests/memory-mode-once.test.ts
@@ -84,6 +84,8 @@ describe('Memory mode "once"', () => {
     expect(spy).toHaveBeenCalledTimes(1);
     // "once" mode must not forward the inbound message as the query.
     expect(spy.mock.calls[0]?.[1]).toBeUndefined();
+    // ...nor the conversation id, which would trigger query expansion.
+    expect(spy.mock.calls[0]?.[2]).toBeUndefined();
   });
 
   it('invalidates the cache on INACTIVE, then re-fetches on the next message', async () => {

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -50,7 +50,7 @@ describe('Memory Functionality', () => {
         startedAt: new Date(),
       };
 
-      const result = await tac.retrieveMemory(session, 'test query');
+      const result = await tac.retrieveMemory(session, 'test query', session.conversationId);
 
       // Result is wrapped in TACMemoryResponse
       expect(result).toBeInstanceOf(TACMemoryResponse);
@@ -63,10 +63,43 @@ describe('Memory Functionality', () => {
           query: 'test query',
           observationsLimit: 20,
           summariesLimit: 5,
-          communicationsLimit: 10,
+          communicationsLimit: 0,
           relevanceThreshold: 0.0,
         }
       );
+    });
+
+    it('should omit conversationId from /Recall when the caller does not pass one', async () => {
+      const tac = await createTestTACWithMemory(getTestConfigWithoutMemory());
+
+      const mockMemoryResponse: MemoryRetrievalResponse = {
+        observations: [],
+        summaries: [],
+        communications: [],
+      };
+
+      const memoryClient = tac.getMemoryClient();
+      expect(memoryClient).toBeDefined();
+      vi.spyOn(memoryClient!, 'retrieveMemories').mockResolvedValue(mockMemoryResponse);
+
+      const session: ConversationSession = {
+        conversationId: 'conv_test_123',
+        profileId: 'mem_profile_existing',
+        channel: 'sms',
+        startedAt: new Date(),
+      };
+
+      // Omitted by the caller, so it must not be pulled off the session.
+      await tac.retrieveMemory(session);
+
+      expect(memoryClient!.retrieveMemories).toHaveBeenCalledWith('mem_profile_existing', {
+        conversationId: undefined,
+        query: undefined,
+        observationsLimit: 20,
+        summariesLimit: 5,
+        communicationsLimit: 0,
+        relevanceThreshold: 0.0,
+      });
     });
 
     it('should auto-lookup profile when missing', async () => {
@@ -100,7 +133,7 @@ describe('Memory Functionality', () => {
         },
       };
 
-      const result = await tac.retrieveMemory(session, 'test query');
+      const result = await tac.retrieveMemory(session, 'test query', session.conversationId);
 
       // Verify profile was looked up
       expect(memoryClient!.lookupProfile).toHaveBeenCalledWith(
@@ -119,7 +152,7 @@ describe('Memory Functionality', () => {
           query: 'test query',
           observationsLimit: 20,
           summariesLimit: 5,
-          communicationsLimit: 10,
+          communicationsLimit: 0,
           relevanceThreshold: 0.0,
         }
       );
@@ -160,7 +193,7 @@ describe('Memory Functionality', () => {
         authorInfo: { address: '+13175556789' },
       };
 
-      await tac.retrieveMemory(session);
+      await tac.retrieveMemory(session, undefined, session.conversationId);
 
       // Verify first profile was used
       expect(session.profileId).toBe('mem_profile_00000000000000000000000001');
@@ -171,7 +204,7 @@ describe('Memory Functionality', () => {
           query: undefined,
           observationsLimit: 20,
           summariesLimit: 5,
-          communicationsLimit: 10,
+          communicationsLimit: 0,
           relevanceThreshold: 0.0,
         }
       );

--- a/tests/voice-channel-active-memory.test.ts
+++ b/tests/voice-channel-active-memory.test.ts
@@ -75,12 +75,14 @@ describe('VoiceChannel - Active Voice Memory Enrichment', () => {
       await (voiceChannel as any).handlePromptMessage('conv123', promptMessage);
 
       // Verify memory was retrieved
+      // "always" sends the transcript as query plus the conversation id.
       expect(retrieveMemorySpy).toHaveBeenCalledWith(
         expect.objectContaining({
           conversationId: 'conv123',
           profileId: 'prof123',
         }),
-        'Hello, I need help'
+        'Hello, I need help',
+        'conv123'
       );
 
       // Verify callback received memory


### PR DESCRIPTION
## Summary

Synced from [python#106](https://github.com/twilio/twilio-agent-connect-python/pull/106). `"once"` mode's cache-priming `/Recall` was paying for a server-side query expansion it got nothing from.

Sending `conversationId` with no `query` makes Memory infer a query from the conversation's history — an LLM call. `"once"` already sends no query, so it bought the cost with no ranking benefit. Now it sends neither, and results come back ordered by recency instead.

Measured on a live store, same profile and conversation:

| `/Recall` | queryTime |
| --- | --- |
| with `conversationId` (before) | 1854ms |
| without (after) | 28ms |

## Changes

- `TAC.retrieveMemory(session, query?, conversationId?)` — new trailing parameter, passed straight to `/Recall` instead of being read off `session.conversationId`. `"always"` passes it explicitly; `"once"` passes neither it nor a query.
- `memoryConfig.communicationsLimit` default **10 → 0**, matching the Memory API and the Python SDK. Required: Memory rejects any `/Recall` with `communicationsLimit > 0` and no `conversationId` (`conversation_id is required when communications_limit is greater than 0`), so without this every `"once"` recall 400s and silently falls back to the Conversations API. This is what the E2E call caught.
- `MemoryClient` logs `query_time_ms` on its retrieval debug line, so the cost stays visible. (Python logs it in `TAC.retrieve_memory`; the TS client is the only place `meta` still exists.)
- `openai-streaming` example uses `memoryMode: 'once'` and actually consumes the memory via `MemoryPromptBuilder`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change — `communicationsLimit` now defaults to 0, so callers relying on the old default get no communications from `/Recall`; and callers relying on `retrieveMemory` implicitly sending `session.conversationId` must now pass it.
- [x] Documentation update
- [ ] Refactoring

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested E2E — real inbound call against ConversationRelay + Conversation Orchestrator + Memory: `query_time_ms: 28`, `sent_conversation_id: false`, no 400, once-mode cache reused on turn two.

`tests/memory.test.ts` pins that omitting the argument sends `conversationId: undefined` rather than reaching into the session; `memory-mode-once` and `voice-channel-active-memory` cover the two modes; `config.test.ts` pins the new default with the reason. Suite: 741 passed.

## SDK Parity

This is the **TypeScript SDK**. If this change affects shared functionality, ensure the [Python SDK](https://github.com/twilio/twilio-agent-connect-python) is updated as well.

- [ ] Change is TypeScript-specific (no Python update needed)
- [x] Python SDK PR created: [python#106](https://github.com/twilio/twilio-agent-connect-python/pull/106) — already merged; this is the TypeScript side.

Note for Python: the same 400 is reachable there by setting `communications_limit > 0` with `"once"` mode. It defaults to 0, so it doesn't bite today.
